### PR TITLE
Adds Throttle, Audit, and Scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.4
+- Add `scan`: fold which returns intermediate values
+- Add `throttle`: block events for a duration after emitting a value
+- Add `audit`: emits the last event received after a duration
+
 ## 0.0.3
 
 - Add `tap`: React to values as they pass without being a subscriber on a stream

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 Contains utility methods to create `StreamTransfomer` instances to manipulate
 Streams.
 
+# audit
+
+Audit waits for a period of time after receiving a value and then only emits
+the most recent value.
+
 # buffer
 
 Collects values from a source stream until a `trigger` stream fires and the
@@ -19,6 +24,11 @@ values that occur within a given duration.
 
 Interleaves events from multiple streams into a single stream.
 
+# scan
+
+Scan is like fold, but instead of producing a single value it yields each 
+intermediate accumulation.
+
 # switchMap, switchLatest
 
 Flatten a Stream of Streams into a Stream which forwards values from the most
@@ -28,3 +38,7 @@ recent Stream
 
 Taps into a single-subscriber stream to react to values as they pass, without
 being a real subscriber.
+
+# throttle
+
+Blocks events for a duration after an event is successfully emitted.

--- a/lib/src/audit.dart
+++ b/lib/src/audit.dart
@@ -5,6 +5,9 @@ import 'dart:async';
 
 /// Creates a StreamTransformer which only emits once per [duration], at the
 /// end of the period.
+///
+/// Like `throttle`, except it always emits the most recently received event in
+/// a period.  Alwyas introduces a delay of at most [duration].
 StreamTransformer<T, T> audit<T>(Duration duration) {
   Timer timer;
   bool shouldClose = false;

--- a/lib/src/audit.dart
+++ b/lib/src/audit.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 /// end of the period.
 ///
 /// Like `throttle`, except it always emits the most recently received event in
-/// a period.  Alwyas introduces a delay of at most [duration].
+/// a period.  Always introduces a delay of at most [duration].
 StreamTransformer<T, T> audit<T>(Duration duration) {
   Timer timer;
   bool shouldClose = false;

--- a/lib/src/audit.dart
+++ b/lib/src/audit.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
+/// Creates a StreamTransformer which only emits once per [duration],
+/// at the end of the period.
+///
+StreamTransformer<T, T> audit<T>(Duration duration) => _auditer(duration);
+
+StreamTransformer<T, T> _auditer<T>(Duration duration) {
+  Timer timer;
+  bool shouldClose = false;
+  T recentData;
+
+  return new StreamTransformer.fromHandlers(
+      handleData: (T data, EventSink<T> sink) {
+    recentData = data;
+    if (timer == null) {
+      timer = new Timer(duration, () {
+        sink.add(recentData);
+        timer = null;
+        if (shouldClose) {
+          sink.close();
+        }
+      });
+    }
+  }, handleDone: (EventSink<T> sink) {
+    if (timer != null) {
+      shouldClose = true;
+    } else {
+      sink.close();
+    }
+  });
+}

--- a/lib/src/audit.dart
+++ b/lib/src/audit.dart
@@ -3,12 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
-/// Creates a StreamTransformer which only emits once per [duration],
-/// at the end of the period.
-///
-StreamTransformer<T, T> audit<T>(Duration duration) => _auditer(duration);
-
-StreamTransformer<T, T> _auditer<T>(Duration duration) {
+/// Creates a StreamTransformer which only emits once per [duration], at the
+/// end of the period.
+StreamTransformer<T, T> audit<T>(Duration duration) {
   Timer timer;
   bool shouldClose = false;
   T recentData;
@@ -16,15 +13,13 @@ StreamTransformer<T, T> _auditer<T>(Duration duration) {
   return new StreamTransformer.fromHandlers(
       handleData: (T data, EventSink<T> sink) {
     recentData = data;
-    if (timer == null) {
-      timer = new Timer(duration, () {
-        sink.add(recentData);
-        timer = null;
-        if (shouldClose) {
-          sink.close();
-        }
-      });
-    }
+    timer ??= new Timer(duration, () {
+      sink.add(recentData);
+      timer = null;
+      if (shouldClose) {
+        sink.close();
+      }
+    });
   }, handleDone: (EventSink<T> sink) {
     if (timer != null) {
       shouldClose = true;

--- a/lib/src/scan.dart
+++ b/lib/src/scan.dart
@@ -5,6 +5,8 @@ import 'dart:async';
 
 typedef S Func2<T, S>(T item, S accumulation);
 
+/// Scan is like fold, but instead of producing a single value it yields
+/// each intermediate accumulation.
 StreamTransformer<T, S> scan<T, S>(Func2<T, S> map, S accumulation) =>
     new _Scan(map, accumulation);
 

--- a/lib/src/scan.dart
+++ b/lib/src/scan.dart
@@ -3,24 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
-typedef S Func2<T, S>(T item, S accumulation);
-
 /// Scan is like fold, but instead of producing a single value it yields
 /// each intermediate accumulation.
-StreamTransformer<T, S> scan<T, S>(Func2<T, S> map, S accumulation) =>
-    new _Scan(map, accumulation);
-
-class _Scan<T, S> implements StreamTransformer<T, S> {
-  final Func2<T, S> _map;
-  S _accumulation;
-
-  _Scan(this._map, this._accumulation);
-
-  @override
-  Stream<S> bind(Stream<T> source) {
-    return source.map((item) {
-      _accumulation = _map(item, _accumulation);
-      return _accumulation;
+StreamTransformer<S, T> scan<S, T>(
+        T initialValue, T combine(T previousValue, S element)) =>
+    new StreamTransformer<S, T>((stream, cancelOnError) {
+      T accumulated = initialValue;
+      return stream
+          .map((value) => accumulated = combine(accumulated, value))
+          .listen(null, cancelOnError: cancelOnError);
     });
-  }
-}

--- a/lib/src/scan.dart
+++ b/lib/src/scan.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
+typedef S Func2<T, S>(T item, S accumulation);
+
+StreamTransformer<T, S> scan<T, S>(Func2<T, S> map, S accumulation) =>
+    new _Scan(map, accumulation);
+
+class _Scan<T, S> implements StreamTransformer<T, S> {
+  final Func2<T, S> _map;
+  S _accumulation;
+
+  _Scan(this._map, this._accumulation);
+
+  @override
+  Stream<S> bind(Stream<T> source) {
+    return source.map((item) {
+      _accumulation = _map(item, _accumulation);
+      return _accumulation;
+    });
+  }
+}

--- a/lib/src/throttle.dart
+++ b/lib/src/throttle.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
+/// Creates a StreamTransformer which only emits once per [duration],
+/// at the beginning of the period.
+///
+StreamTransformer<T, T> throttle<T>(Duration duration) => _throttler(duration);
+
+StreamTransformer<T, T> _throttler<T>(Duration duration) {
+  Timer timer;
+
+  return new StreamTransformer.fromHandlers(handleData: (data, sink) {
+    if (timer == null) {
+      sink.add(data);
+      timer = new Timer(duration, () {
+        timer = null;
+      });
+    }
+  }, handleDone: (sink) {
+    sink.close();
+  });
+}

--- a/lib/src/throttle.dart
+++ b/lib/src/throttle.dart
@@ -6,9 +6,7 @@ import 'dart:async';
 /// Creates a StreamTransformer which only emits once per [duration],
 /// at the beginning of the period.
 ///
-StreamTransformer<T, T> throttle<T>(Duration duration) => _throttler(duration);
-
-StreamTransformer<T, T> _throttler<T>(Duration duration) {
+StreamTransformer<T, T> throttle<T>(Duration duration) {
   Timer timer;
 
   return new StreamTransformer.fromHandlers(handleData: (data, sink) {

--- a/lib/src/throttle.dart
+++ b/lib/src/throttle.dart
@@ -3,9 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
-/// Creates a StreamTransformer which only emits once per [duration],
-/// at the beginning of the period.
-///
+/// Creates a StreamTransformer which only emits once per [duration], at the
+/// beginning of the period.
 StreamTransformer<T, T> throttle<T>(Duration duration) {
   Timer timer;
 

--- a/lib/stream_transform.dart
+++ b/lib/stream_transform.dart
@@ -8,3 +8,6 @@ export 'src/debounce.dart';
 export 'src/merge.dart';
 export 'src/switch.dart';
 export 'src/tap.dart';
+export 'src/scan.dart';
+export 'src/throttle.dart';
+export 'src/audit.dart';

--- a/test/audit_test.dart
+++ b/test/audit_test.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+import 'package:test/test.dart';
+import 'package:stream_transform/stream_transform.dart';
+
+void main() {
+  var streamTypes = {
+    'single subscription': () => new StreamController(),
+    'broadcast': () => new StreamController.broadcast()
+  };
+  for (var streamType in streamTypes.keys) {
+    group('Stream type [$streamType]', () {
+      StreamController values;
+      List emittedValues;
+      bool valuesCanceled;
+      bool isDone;
+      List errors;
+      StreamSubscription subscription;
+
+      void setUpStreams(StreamTransformer transformer) {
+        valuesCanceled = false;
+        values = streamTypes[streamType]()
+          ..onCancel = () {
+            valuesCanceled = true;
+          };
+        emittedValues = [];
+        errors = [];
+        isDone = false;
+        subscription = values.stream
+            .transform(transformer)
+            .listen(emittedValues.add, onError: errors.add, onDone: () {
+          isDone = true;
+        });
+      }
+
+      group('audit', () {
+        setUp(() async {
+          setUpStreams(audit(const Duration(milliseconds: 5)));
+        });
+
+        test('cancels values', () async {
+          await subscription.cancel();
+          expect(valuesCanceled, true);
+        });
+
+        test('swallows values that come faster than duration', () async {
+          values.add(1);
+          values.add(2);
+          await values.close();
+          await new Future.delayed(const Duration(milliseconds: 10));
+          expect(emittedValues, [2]);
+        });
+
+        test('outputs multiple values spaced further than duration', () async {
+          values.add(1);
+          await new Future.delayed(const Duration(milliseconds: 10));
+          values.add(2);
+          await new Future.delayed(const Duration(milliseconds: 10));
+          expect(emittedValues, [1, 2]);
+        });
+
+        test('waits for pending value to close', () async {
+          values.add(1);
+          await new Future.delayed(const Duration(milliseconds: 10));
+          await values.close();
+          await new Future(() {});
+          expect(isDone, true);
+        });
+
+        test('closes output if there are no pending values', () async {
+          values.add(1);
+          await new Future.delayed(const Duration(milliseconds: 10));
+          values.add(2);
+          await new Future(() {});
+          await values.close();
+          expect(isDone, false);
+          await new Future.delayed(const Duration(milliseconds: 10));
+          expect(isDone, true);
+        });
+      });
+    });
+  }
+}

--- a/test/scan_test.dart
+++ b/test/scan_test.dart
@@ -9,7 +9,7 @@ void main() {
     test('produces intermediate values', () async {
       var source = new Stream.fromIterable([1, 2, 3, 4]);
       var sum = (int x, int y) => x + y;
-      var result = await source.transform(scan(sum, 0)).toList();
+      var result = await source.transform(scan(0, sum)).toList();
 
       expect(result, [1, 3, 6, 10]);
     });

--- a/test/scan_test.dart
+++ b/test/scan_test.dart
@@ -1,0 +1,17 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:stream_transform/stream_transform.dart';
+
+void main() {
+  group('Scan', () {
+    test('produces intermediate values', () async {
+      var source = new Stream.fromIterable([1, 2, 3, 4]);
+      var sum = (int x, int y) => x + y;
+      var result = await source.transform(scan(sum, 0)).toList();
+
+      expect(result, [1, 3, 6, 10]);
+    });
+  });
+}

--- a/test/throttle_test.dart
+++ b/test/throttle_test.dart
@@ -58,14 +58,6 @@ void main() {
           expect(emittedValues, [1, 2]);
         });
 
-        test('waits for pending value to close', () async {
-          values.add(1);
-          await new Future.delayed(const Duration(milliseconds: 10));
-          await values.close();
-          await new Future(() {});
-          expect(isDone, true);
-        });
-
         test('closes output immediately', () async {
           values.add(1);
           await new Future.delayed(const Duration(milliseconds: 10));

--- a/test/throttle_test.dart
+++ b/test/throttle_test.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+import 'package:test/test.dart';
+import 'package:stream_transform/stream_transform.dart';
+
+void main() {
+  var streamTypes = {
+    'single subscription': () => new StreamController(),
+    'broadcast': () => new StreamController.broadcast()
+  };
+  for (var streamType in streamTypes.keys) {
+    group('Stream type [$streamType]', () {
+      StreamController values;
+      List emittedValues;
+      bool valuesCanceled;
+      bool isDone;
+      List errors;
+      StreamSubscription subscription;
+
+      void setUpStreams(StreamTransformer transformer) {
+        valuesCanceled = false;
+        values = streamTypes[streamType]()
+          ..onCancel = () {
+            valuesCanceled = true;
+          };
+        emittedValues = [];
+        errors = [];
+        isDone = false;
+        subscription = values.stream
+            .transform(transformer)
+            .listen(emittedValues.add, onError: errors.add, onDone: () {
+          isDone = true;
+        });
+      }
+
+      group('throttle', () {
+        setUp(() async {
+          setUpStreams(throttle(const Duration(milliseconds: 5)));
+        });
+
+        test('cancels values', () async {
+          await subscription.cancel();
+          expect(valuesCanceled, true);
+        });
+
+        test('swallows values that come faster than duration', () async {
+          values.add(1);
+          values.add(2);
+          await values.close();
+          await new Future.delayed(const Duration(milliseconds: 10));
+          expect(emittedValues, [1]);
+        });
+
+        test('outputs multiple values spaced further than duration', () async {
+          values.add(1);
+          await new Future.delayed(const Duration(milliseconds: 10));
+          values.add(2);
+          await new Future.delayed(const Duration(milliseconds: 10));
+          expect(emittedValues, [1, 2]);
+        });
+
+        test('waits for pending value to close', () async {
+          values.add(1);
+          await new Future.delayed(const Duration(milliseconds: 10));
+          await values.close();
+          await new Future(() {});
+          expect(isDone, true);
+        });
+
+        test('closes output immediately', () async {
+          values.add(1);
+          await new Future.delayed(const Duration(milliseconds: 10));
+          values.add(2);
+          await new Future(() {});
+          await values.close();
+          expect(isDone, true);
+        });
+      });
+    });
+  }
+}


### PR DESCRIPTION
Throttle: emits immediately, then swallows values until duration elapses

Audit: like throttle, but it emits the most recent value at the end of the duration.

Scan: a fold which yield the intermediate accumulations.

cc @natebosch for review?