### PR TITLE
Fix non-strong compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5
+
+- Bug Fix: Allow compiling switchLatest with Dart2Js.
+
 ## 0.0.4
 - Add `scan`: fold which returns intermediate values
 - Add `throttle`: block events for a duration after emitting a value

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -25,7 +25,7 @@ StreamTransformer<S, T> switchMap<S, T>(Stream<T> map(S event)) =>
 /// If the source stream is a broadcast stream, the result stream will be as
 /// well, regardless of the types of streams emitted.
 StreamTransformer<Stream<T>, T> switchLatest<T>() =>
-    const _SwitchTransformer<T>();
+    new _SwitchTransformer<T>();
 
 class _SwitchTransformer<T> implements StreamTransformer<Stream<T>, T> {
   const _SwitchTransformer();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 author: Dart Team <misc@dartlang.org>
 homepage: https://www.github.com/dart-lang/stream_transform
-version: 0.0.4
+version: 0.0.5-dev
 
 environment:
   sdk: ">=1.22.0 <2.0.0"


### PR DESCRIPTION
Did not see this with strong mode analyzer. In Dart2Js generic type
arguments are not allowed on const constructor calls.