### PR TITLE
Fix broadcast bug for Audit and clarify behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 0.0.6
 
-- Bug Fix: `debounce` correctly adds data to all listeners on a broadcast
-  stream.
+- Bug Fix: Some transformers did not correctly add date to all listeners on
+  broadcast streams. Fixed for:
+  - `debounce`
+  - `audit`
+
 
 ## 0.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
 ## 0.0.6
 
-- Bug Fix: Some transformers did not correctly add date to all listeners on
-  broadcast streams. Fixed for:
-  - `debounce`
-  - `audit`
-
+- Bug Fix: Some transformers did not correctly add data to all listeners on
+  broadcast streams. Fixed for `debounce`, and `audit`.
 
 ## 0.0.5
 

--- a/lib/src/audit.dart
+++ b/lib/src/audit.dart
@@ -3,18 +3,25 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
+import 'from_handlers.dart';
+
 /// Creates a StreamTransformer which only emits once per [duration], at the
 /// end of the period.
 ///
-/// Like `throttle`, except it always emits the most recently received event in
-/// a period.  Always introduces a delay of at most [duration].
+/// Always introduces a delay of at most [duration].
+///
+/// Differs from `throttle` in that it always emits the most recently received
+/// event rather than the first in the period.
+///
+/// Differs from `debounce` in that a value will always be emitted after
+/// [duration], the output will not be starved by values coming in repeatedly
+/// within [duration].
 StreamTransformer<T, T> audit<T>(Duration duration) {
   Timer timer;
   bool shouldClose = false;
   T recentData;
 
-  return new StreamTransformer.fromHandlers(
-      handleData: (T data, EventSink<T> sink) {
+  return fromHandlers(handleData: (T data, EventSink<T> sink) {
     recentData = data;
     timer ??= new Timer(duration, () {
       sink.add(recentData);


### PR DESCRIPTION
- Use `fromHandlers` to correctly handle broadcast Streams.
- Clarify in the Doc comment the behavior difference from `debounce`
- Add a test which makes explicit the difference from `debounce`, all
  the other tests also pass with `debounce`.