### PR TITLE
Use sync forwarders in `fromHandlers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   broadcast streams. Fixed for `throttle`, `debounce`, and `audit`.
 - Bug Fix: Only call the `tap` data callback once per event rather than once per
   listener.
+- Use sync `StreamControllers` for forwarding where possible.
 
 ## 0.0.5
 

--- a/lib/src/from_handlers.dart
+++ b/lib/src/from_handlers.dart
@@ -46,9 +46,9 @@ class _StreamTransformer<S, T> implements StreamTransformer<S, T> {
   Stream<T> bind(Stream<S> values) {
     StreamController<T> controller;
     if (values.isBroadcast) {
-      controller = new StreamController<T>.broadcast();
+      controller = new StreamController<T>.broadcast(sync: true);
     } else {
-      controller = new StreamController<T>();
+      controller = new StreamController<T>(sync: true);
     }
     StreamSubscription<S> subscription;
     controller.onListen = () {
@@ -67,12 +67,9 @@ class _StreamTransformer<S, T> implements StreamTransformer<S, T> {
       controller.onResume = () => subscription?.resume();
     }
     controller.onCancel = () {
-      if (controller.hasListener || subscription == null) {
-        return new Future.value();
-      }
-      var toCancel = subscription;
+      if (controller.hasListener || subscription == null) return;
+      subscription.cancel();
       subscription = null;
-      return toCancel.cancel();
     };
     return controller.stream;
   }

--- a/test/audit_test.dart
+++ b/test/audit_test.dart
@@ -61,9 +61,9 @@ void main() {
 
         test('waits for pending value to close', () async {
           values.add(1);
-          await new Future.delayed(const Duration(milliseconds: 10));
           await values.close();
-          await new Future(() {});
+          expect(isDone, false);
+          await new Future.delayed(const Duration(milliseconds: 10));
           expect(isDone, true);
         });
 
@@ -71,7 +71,6 @@ void main() {
           values.add(1);
           await new Future.delayed(const Duration(milliseconds: 10));
           values.add(2);
-          await new Future(() {});
           await values.close();
           expect(isDone, false);
           await new Future.delayed(const Duration(milliseconds: 10));

--- a/test/from_handlers_test.dart
+++ b/test/from_handlers_test.dart
@@ -55,7 +55,6 @@ void main() {
 
       test('forwards done', () async {
         await values.close();
-        await new Future(() {});
         expect(isDone, true);
       });
 
@@ -103,7 +102,6 @@ void main() {
 
       test('forwards done', () async {
         await values.close();
-        await new Future(() {});
         expect(isDone, true);
         expect(isDone2, true);
       });

--- a/test/throttle_test.dart
+++ b/test/throttle_test.dart
@@ -63,9 +63,7 @@ void main() {
           values.add(1);
           await new Future.delayed(const Duration(milliseconds: 10));
           values.add(2);
-          await new Future(() {});
           await values.close();
-          await new Future(() {});
           expect(isDone, true);
         });
 


### PR DESCRIPTION
Towards dart-lang/tools#1754

- Drop the return values from the onCancel callback. For
  single-subscription StreamController instances this is in the path
  before onDone is forwarded so we don't want or need to wait for a
  Future here.
- Drop the now unnecessary `await new Future(() {})` from tests.