### PR TITLE
Use sync forwarders for `merge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   broadcast streams. Fixed for `throttle`, `debounce`, and `audit`.
 - Bug Fix: Only call the `tap` data callback once per event rather than once per
   listener.
+- Bug Fix: Allow canceling and re-listening to broadcast streams after a
+  `merge` transform.
 - Use sync `StreamControllers` for forwarding where possible.
 
 ## 0.0.5


### PR DESCRIPTION
Towards dart-lang/tools#1754

Also fix a bug where canceling the subscription on a broadcast stream
would cancel single-subscription streams merged in and not allow
subsequent listeners.

- Use sync StreamControllers
- If the first stream is a broadcast, also translate all merged streams
  to broadcast so they can be canceled and relistened. Add a note to the
  Doc comment warning that single-subscription streams merged into a
  broadcast stream may never be canceled.
- Move onPause, onResume, and onCancel initialization inside onListen
  callback - they don't need to exist before initialization.
- Only cancel input subscriptions if they aren't all done.
- Add test for onDone forwarding.
- Add test for canceling and relistening on broadcast streams.