### PR TITLE
Ensure timers are started before awaits in tests

### DIFF
--- a/test/audit_test.dart
+++ b/test/audit_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/audit_test.dart
+++ b/test/audit_test.dart
@@ -91,7 +91,8 @@ void main() {
           values.add(2);
           await new Future.delayed(const Duration(milliseconds: 3));
           values.add(3);
-          expect(emittedValues, [2]);
+          await waitForTimer(5);
+          expect(emittedValues, [2, 3]);
         });
 
         if (streamType == 'broadcast') {

--- a/test/audit_test.dart
+++ b/test/audit_test.dart
@@ -47,15 +47,15 @@ void main() {
           values.add(1);
           values.add(2);
           await values.close();
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           expect(emittedValues, [2]);
         });
 
         test('outputs multiple values spaced further than duration', () async {
           values.add(1);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           values.add(2);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           expect(emittedValues, [1, 2]);
         });
 
@@ -63,17 +63,17 @@ void main() {
           values.add(1);
           await values.close();
           expect(isDone, false);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           expect(isDone, true);
         });
 
         test('closes output if there are no pending values', () async {
           values.add(1);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           values.add(2);
           await values.close();
           expect(isDone, false);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           expect(isDone, true);
         });
 
@@ -93,7 +93,7 @@ void main() {
             transformed.listen(otherValues.add);
             values.add(1);
             values.add(2);
-            await new Future.delayed(const Duration(milliseconds: 10));
+            await _waitForTimer(5);
             expect(emittedValues, [2]);
             expect(otherValues, [2]);
           });
@@ -102,3 +102,9 @@ void main() {
     });
   }
 }
+
+/// Cycle the event loop to ensure timers are started, then wait for a delay
+/// longer than [milliseconds] to allow for the timer to fire.
+Future _waitForTimer(int milliseconds) =>
+    new Future(() {/* ensure Timer is started*/}).then((_) =>
+        new Future.delayed(new Duration(milliseconds: milliseconds + 1)));

--- a/test/audit_test.dart
+++ b/test/audit_test.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+
 import 'package:test/test.dart';
 import 'package:stream_transform/stream_transform.dart';
+
+import 'utils.dart';
 
 void main() {
   var streamTypes = {
@@ -47,15 +50,15 @@ void main() {
           values.add(1);
           values.add(2);
           await values.close();
-          await _waitForTimer(5);
+          await waitForTimer(5);
           expect(emittedValues, [2]);
         });
 
         test('outputs multiple values spaced further than duration', () async {
           values.add(1);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           values.add(2);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           expect(emittedValues, [1, 2]);
         });
 
@@ -63,17 +66,17 @@ void main() {
           values.add(1);
           await values.close();
           expect(isDone, false);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           expect(isDone, true);
         });
 
         test('closes output if there are no pending values', () async {
           values.add(1);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           values.add(2);
           await values.close();
           expect(isDone, false);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           expect(isDone, true);
         });
 
@@ -93,7 +96,7 @@ void main() {
             transformed.listen(otherValues.add);
             values.add(1);
             values.add(2);
-            await _waitForTimer(5);
+            await waitForTimer(5);
             expect(emittedValues, [2]);
             expect(otherValues, [2]);
           });
@@ -102,9 +105,3 @@ void main() {
     });
   }
 }
-
-/// Cycle the event loop to ensure timers are started, then wait for a delay
-/// longer than [milliseconds] to allow for the timer to fire.
-Future _waitForTimer(int milliseconds) =>
-    new Future(() {/* ensure Timer is started*/}).then((_) =>
-        new Future.delayed(new Duration(milliseconds: milliseconds + 1)));

--- a/test/debounce_test.dart
+++ b/test/debounce_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/debounce_test.dart
+++ b/test/debounce_test.dart
@@ -47,21 +47,21 @@ void main() {
           values.add(1);
           values.add(2);
           await values.close();
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           expect(emittedValues, [2]);
         });
 
         test('outputs multiple values spaced further than duration', () async {
           values.add(1);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           values.add(2);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           expect(emittedValues, [1, 2]);
         });
 
         test('waits for pending value to close', () async {
           values.add(1);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           await values.close();
           await new Future(() {});
           expect(isDone, true);
@@ -69,12 +69,12 @@ void main() {
 
         test('closes output if there are no pending values', () async {
           values.add(1);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           values.add(2);
           await new Future(() {});
           await values.close();
           expect(isDone, false);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           expect(isDone, true);
         });
 
@@ -84,7 +84,7 @@ void main() {
             transformed.listen(otherValues.add);
             values.add(1);
             values.add(2);
-            await new Future.delayed(const Duration(milliseconds: 10));
+            await _waitForTimer(5);
             expect(emittedValues, [2]);
             expect(otherValues, [2]);
           });
@@ -100,7 +100,7 @@ void main() {
           values.add(1);
           values.add(2);
           await values.close();
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           expect(emittedValues, [
             [1, 2]
           ]);
@@ -109,9 +109,9 @@ void main() {
         test('separate lists for multiple values spaced further than duration',
             () async {
           values.add(1);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           values.add(2);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           expect(emittedValues, [
             [1],
             [2]
@@ -124,7 +124,7 @@ void main() {
             transformed.listen(otherValues.add);
             values.add(1);
             values.add(2);
-            await new Future.delayed(const Duration(milliseconds: 10));
+            await _waitForTimer(5);
             expect(emittedValues, [
               [1, 2]
             ]);
@@ -137,3 +137,9 @@ void main() {
     });
   }
 }
+
+/// Cycle the event loop to ensure timers are started, then wait for a delay
+/// longer than [milliseconds] to allow for the timer to fire.
+Future _waitForTimer(int milliseconds) =>
+    new Future(() {/* ensure Timer is started*/}).then((_) =>
+        new Future.delayed(new Duration(milliseconds: milliseconds + 1)));

--- a/test/debounce_test.dart
+++ b/test/debounce_test.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+
 import 'package:test/test.dart';
 import 'package:stream_transform/stream_transform.dart';
+
+import 'utils.dart';
 
 void main() {
   var streamTypes = {
@@ -47,21 +50,21 @@ void main() {
           values.add(1);
           values.add(2);
           await values.close();
-          await _waitForTimer(5);
+          await waitForTimer(5);
           expect(emittedValues, [2]);
         });
 
         test('outputs multiple values spaced further than duration', () async {
           values.add(1);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           values.add(2);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           expect(emittedValues, [1, 2]);
         });
 
         test('waits for pending value to close', () async {
           values.add(1);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           await values.close();
           await new Future(() {});
           expect(isDone, true);
@@ -69,12 +72,12 @@ void main() {
 
         test('closes output if there are no pending values', () async {
           values.add(1);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           values.add(2);
           await new Future(() {});
           await values.close();
           expect(isDone, false);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           expect(isDone, true);
         });
 
@@ -84,7 +87,7 @@ void main() {
             transformed.listen(otherValues.add);
             values.add(1);
             values.add(2);
-            await _waitForTimer(5);
+            await waitForTimer(5);
             expect(emittedValues, [2]);
             expect(otherValues, [2]);
           });
@@ -100,7 +103,7 @@ void main() {
           values.add(1);
           values.add(2);
           await values.close();
-          await _waitForTimer(5);
+          await waitForTimer(5);
           expect(emittedValues, [
             [1, 2]
           ]);
@@ -109,9 +112,9 @@ void main() {
         test('separate lists for multiple values spaced further than duration',
             () async {
           values.add(1);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           values.add(2);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           expect(emittedValues, [
             [1],
             [2]
@@ -124,7 +127,7 @@ void main() {
             transformed.listen(otherValues.add);
             values.add(1);
             values.add(2);
-            await _waitForTimer(5);
+            await waitForTimer(5);
             expect(emittedValues, [
               [1, 2]
             ]);
@@ -137,9 +140,3 @@ void main() {
     });
   }
 }
-
-/// Cycle the event loop to ensure timers are started, then wait for a delay
-/// longer than [milliseconds] to allow for the timer to fire.
-Future _waitForTimer(int milliseconds) =>
-    new Future(() {/* ensure Timer is started*/}).then((_) =>
-        new Future.delayed(new Duration(milliseconds: milliseconds + 1)));

--- a/test/throttle_test.dart
+++ b/test/throttle_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/test/throttle_test.dart
+++ b/test/throttle_test.dart
@@ -47,21 +47,21 @@ void main() {
           values.add(1);
           values.add(2);
           await values.close();
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           expect(emittedValues, [1]);
         });
 
         test('outputs multiple values spaced further than duration', () async {
           values.add(1);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           values.add(2);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           expect(emittedValues, [1, 2]);
         });
 
         test('closes output immediately', () async {
           values.add(1);
-          await new Future.delayed(const Duration(milliseconds: 10));
+          await _waitForTimer(5);
           values.add(2);
           await values.close();
           expect(isDone, true);
@@ -81,3 +81,9 @@ void main() {
     });
   }
 }
+
+/// Cycle the event loop to ensure timers are started, then wait for a delay
+/// longer than [milliseconds] to allow for the timer to fire.
+Future _waitForTimer(int milliseconds) =>
+    new Future(() {/* ensure Timer is started*/}).then((_) =>
+        new Future.delayed(new Duration(milliseconds: milliseconds + 1)));

--- a/test/throttle_test.dart
+++ b/test/throttle_test.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+
 import 'package:test/test.dart';
 import 'package:stream_transform/stream_transform.dart';
+
+import 'utils.dart';
 
 void main() {
   var streamTypes = {
@@ -47,21 +50,21 @@ void main() {
           values.add(1);
           values.add(2);
           await values.close();
-          await _waitForTimer(5);
+          await waitForTimer(5);
           expect(emittedValues, [1]);
         });
 
         test('outputs multiple values spaced further than duration', () async {
           values.add(1);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           values.add(2);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           expect(emittedValues, [1, 2]);
         });
 
         test('closes output immediately', () async {
           values.add(1);
-          await _waitForTimer(5);
+          await waitForTimer(5);
           values.add(2);
           await values.close();
           expect(isDone, true);
@@ -81,9 +84,3 @@ void main() {
     });
   }
 }
-
-/// Cycle the event loop to ensure timers are started, then wait for a delay
-/// longer than [milliseconds] to allow for the timer to fire.
-Future _waitForTimer(int milliseconds) =>
-    new Future(() {/* ensure Timer is started*/}).then((_) =>
-        new Future.delayed(new Duration(milliseconds: milliseconds + 1)));

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,0 +1,7 @@
+import 'dart:async';
+
+/// Cycle the event loop to ensure timers are started, then wait for a delay
+/// longer than [milliseconds] to allow for the timer to fire.
+Future waitForTimer(int milliseconds) =>
+    new Future(() {/* ensure Timer is started*/}).then((_) =>
+        new Future.delayed(new Duration(milliseconds: milliseconds + 1)));

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 /// Cycle the event loop to ensure timers are started, then wait for a delay


### PR DESCRIPTION
Fixes dart-lang/tools#1755

These tests were relying on a 5ms Timer getting started asynchronously
and firing before a 10ms delay which is not guaranteed. By waiting an
extra cycle through the event loop to ensure that the Timer starts
before the delay we can have a better guarantee of ordering.