### PR TITLE
Use sync forwarders for `switchLatest`

### DIFF
--- a/test/switch_test.dart
+++ b/test/switch_test.dart
@@ -82,12 +82,9 @@ void main() {
           await new Future(() {});
 
           await outer.close();
-
           expect(isDone, false);
 
           await second.close();
-
-          await new Future(() {});
           expect(isDone, true);
         });
 
@@ -97,11 +94,9 @@ void main() {
           outer.add(first.stream);
           await new Future(() {});
           await first.close();
-          await new Future(() {});
           expect(isDone, false);
 
           await outer.close();
-          await new Future(() {});
           expect(isDone, true);
         });
 


### PR DESCRIPTION
Towards dart-lang/tools#1754

- Don't return a Future from `onCancel` when the values were already
  done.
- Use `sync: true`
- Drop unnecessary `await new Future(() {})`s
- Set onPause, onResume, and onCancel inside onListen.
- Remove innerStreamDone boolean and instead check for a null subscription.