### PR TITLE
Use sync forwarders in buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   listener.
 - Bug Fix: Allow canceling and re-listening to broadcast streams after a
   `merge` transform.
+- Bug Fix: Broadcast streams which are buffered using a single-subscription
+  trigger can be canceled and re-listened.
+- Bug Fix: Buffer outputs one more value if there is a pending trigger before
+  the trigger closes.
 - Use sync `StreamControllers` for forwarding where possible.
 
 ## 0.0.5


### PR DESCRIPTION
Towards dart-lang/tools#1754

Fixes a bug where the output would close too soon if there was a pending
trigger.

Fixes some bugs in the test.

Fixes a bug with canceling when values are broadcast but trigger is
single subscription.

Refactor for better readability

- Fix tests to pass the valuesType instead of the triggerType for both
  streams.
- Refactor for more clear parallel structure between handlers for values
  and triggers.
- Inline _collectToList
- Add booleans to track when streams are done rather than overload what
  it means for their subscriptions to be null.
- Only return a Future from onCancel when there were streams open that
  needed to be canceled. This means that some of the extra awaits in
  tests need to be left in to properly forward errors closing stream.
- Pull the trigger canceling tests out of the loops since the behavior
  depends on both stream types.
- Cancel rather than pause trigger subscription if we won't need it
  again.
- Add tests that broadcast stream (from values) can be canceled and
  relistened
- Set up onPause, onResume, and onCancel in onListen