### PR TITLE
Rewrite concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   listener.
 - Bug Fix: Allow canceling and re-listening to broadcast streams after a
   `merge` transform.
+- Bug Fix: Single-subscription streams concatted after broadcast streams are
+  handled correctly.
 - Use sync `StreamControllers` for forwarding where possible.
 
 ## 0.0.5

--- a/lib/src/concat.dart
+++ b/lib/src/concat.dart
@@ -11,6 +11,12 @@ import 'dart:async';
 ///
 /// If a single-subscription is concatted to the end of a broadcast stream it
 /// may be listened to and never canceled.
+///
+/// If a broadcast stream is concatted to any other stream it will miss any
+/// events which occur before the first stream is done. If a broadcast stream is
+/// concatted to a single-subscription stream, pausing the stream while it is
+/// listening to the second stream will cause events to be dropped rather than
+/// buffered.
 StreamTransformer<T, T> concat<T>(Stream<T> next) => new _Concat<T>(next);
 
 class _Concat<T> implements StreamTransformer<T, T> {

--- a/test/concat_test.dart
+++ b/test/concat_test.dart
@@ -68,13 +68,15 @@ void main() {
           expect(secondListened, true);
         });
 
-        test('cancels single-subscription first stream on cancel', () async {
+        test('cancels any type of first stream on cancel', () async {
           await subscription.cancel();
           expect(firstCanceled, true);
         });
 
         if (firstType == 'single-subscription') {
-          test('cancels single-subscription second stream on cancel', () async {
+          test(
+              'cancels any type of second stream on cancel if first is '
+              'broadcast', () async {
             await first.close();
             await subscription.cancel();
             expect(secondCanceled, true);

--- a/test/concat_test.dart
+++ b/test/concat_test.dart
@@ -79,7 +79,7 @@ void main() {
           expect(firstCanceled, true);
         });
 
-        if (firstType == 'single-subscription') {
+        if (firstType == 'single subscription') {
           test(
               'cancels any type of second stream on cancel if first is '
               'broadcast', () async {
@@ -87,6 +87,32 @@ void main() {
             await subscription.cancel();
             expect(secondCanceled, true);
           });
+
+          if (secondType == 'broadcast') {
+            test('can pause and resume during second stream - dropping values',
+                () async {
+              await first.close();
+              subscription.pause();
+              second.add(1);
+              await new Future(() {});
+              subscription.resume();
+              second.add(2);
+              await new Future(() {});
+              expect(emittedValues, [2]);
+            });
+          } else {
+            test('can pause and resume during second stream - buffering values',
+                () async {
+              await first.close();
+              subscription.pause();
+              second.add(1);
+              await new Future(() {});
+              subscription.resume();
+              second.add(2);
+              await new Future(() {});
+              expect(emittedValues, [1, 2]);
+            });
+          }
         }
 
         if (firstType == 'broadcast') {

--- a/test/concat_test.dart
+++ b/test/concat_test.dart
@@ -100,10 +100,12 @@ void main() {
           test('can cancel and relisten during second stream', () async {
             await first.close();
             await subscription.cancel();
-            subscription = transformed.listen(emittedValues.add);
             second.add(2);
+            await new Future(() {});
+            subscription = transformed.listen(emittedValues.add);
+            second.add(3);
             await new Future((() {}));
-            expect(emittedValues, [2]);
+            expect(emittedValues, [3]);
           });
 
           test('forwards values to multiple listeners', () async {

--- a/test/concat_test.dart
+++ b/test/concat_test.dart
@@ -8,40 +8,121 @@ import 'package:test/test.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 void main() {
-  group('concat', () {
-    test('adds all values from both streams', () async {
-      var first = new Stream.fromIterable([1, 2, 3]);
-      var second = new Stream.fromIterable([4, 5, 6]);
-      var all = await first.transform(concat(second)).toList();
-      expect(all, [1, 2, 3, 4, 5, 6]);
-    });
+  var streamTypes = {
+    'single subscription': () => new StreamController(),
+    'broadcast': () => new StreamController.broadcast()
+  };
+  for (var firstType in streamTypes.keys) {
+    for (var secondType in streamTypes.keys) {
+      group('concat [$firstType] with [$secondType]', () {
+        StreamController first;
+        StreamController second;
 
-    test('closes first stream on cancel', () async {
-      var firstStreamClosed = false;
-      var first = new StreamController()
-        ..onCancel = () {
-          firstStreamClosed = true;
-        };
-      var second = new StreamController();
-      var subscription =
-          first.stream.transform(concat(second.stream)).listen((_) {});
-      await subscription.cancel();
-      expect(firstStreamClosed, true);
-    });
+        List emittedValues;
+        bool firstCanceled;
+        bool secondCanceled;
+        bool secondListened;
+        bool isDone;
+        List errors;
+        Stream transformed;
+        StreamSubscription subscription;
 
-    test('closes second stream on cancel if first stream done', () async {
-      var first = new StreamController();
-      var secondStreamClosed = false;
-      var second = new StreamController()
-        ..onCancel = () {
-          secondStreamClosed = true;
-        };
-      var subscription =
-          first.stream.transform(concat(second.stream)).listen((_) {});
-      await first.close();
-      await new Future(() {});
-      await subscription.cancel();
-      expect(secondStreamClosed, true);
-    });
-  });
+        setUp(() async {
+          firstCanceled = false;
+          secondCanceled = false;
+          secondListened = false;
+          first = streamTypes[firstType]()
+            ..onCancel = () {
+              firstCanceled = true;
+            };
+          second = streamTypes[secondType]()
+            ..onCancel = () {
+              secondCanceled = true;
+            }
+            ..onListen = () {
+              secondListened = true;
+            };
+          emittedValues = [];
+          errors = [];
+          isDone = false;
+          transformed = first.stream.transform(concat(second.stream));
+          subscription = transformed
+              .listen(emittedValues.add, onError: errors.add, onDone: () {
+            isDone = true;
+          });
+        });
+
+        test('adds all values from both streams', () async {
+          first..add(1)..add(2);
+          await first.close();
+          await new Future(() {});
+          second..add(3)..add(4);
+          await new Future(() {});
+          expect(emittedValues, [1, 2, 3, 4]);
+        });
+
+        test('Does not listen to second stream before first stream finishes',
+            () async {
+          expect(secondListened, false);
+          await first.close();
+          expect(secondListened, true);
+        });
+
+        test('cancels single-subscription first stream on cancel', () async {
+          await subscription.cancel();
+          expect(firstCanceled, true);
+        });
+
+        if (firstType == 'single-subscription') {
+          test('cancels single-subscription second stream on cancel', () async {
+            await first.close();
+            await subscription.cancel();
+            expect(secondCanceled, true);
+          });
+        }
+
+        test('closes stream after both inputs close', () async {
+          await first.close();
+          await second.close();
+          expect(isDone, true);
+        });
+
+        if (firstType == 'broadcast') {
+          test('can cancel and relisten during first stream', () async {
+            await subscription.cancel();
+            first.add(1);
+            subscription = transformed.listen(emittedValues.add);
+            first.add(2);
+            await new Future(() {});
+            expect(emittedValues, [2]);
+          });
+
+          test('can cancel and relisten during second stream', () async {
+            await first.close();
+            await subscription.cancel();
+            subscription = transformed.listen(emittedValues.add);
+            second.add(2);
+            await new Future((() {}));
+            expect(emittedValues, [2]);
+          });
+
+          test('forwards values to multiple listeners', () async {
+            var otherValues = [];
+            transformed.listen(otherValues.add);
+            first.add(1);
+            await first.close();
+            second.add(2);
+            await new Future(() {});
+            var thirdValues = [];
+            transformed.listen(thirdValues.add);
+            second.add(3);
+            await new Future(() {});
+            expect(emittedValues, [1, 2, 3]);
+            expect(otherValues, [1, 2, 3]);
+            expect(thirdValues, [3]);
+          });
+        }
+      });
+    }
+  }
 }

--- a/test/concat_test.dart
+++ b/test/concat_test.dart
@@ -68,6 +68,12 @@ void main() {
           expect(secondListened, true);
         });
 
+        test('closes stream after both inputs close', () async {
+          await first.close();
+          await second.close();
+          expect(isDone, true);
+        });
+
         test('cancels any type of first stream on cancel', () async {
           await subscription.cancel();
           expect(firstCanceled, true);
@@ -82,12 +88,6 @@ void main() {
             expect(secondCanceled, true);
           });
         }
-
-        test('closes stream after both inputs close', () async {
-          await first.close();
-          await second.close();
-          expect(isDone, true);
-        });
 
         if (firstType == 'broadcast') {
           test('can cancel and relisten during first stream', () async {


### PR DESCRIPTION
Uses sync forwarders for dart-lang/tools#1754

The simple implementation leaves out a lot of edge cases around
single-subscription vs broadcast streams and how they combine. Rewrite
to handle pause, resume, and cancel manually.

- Loop over stream types in tests
- Add test for onDone and canceling and relistening
- Handle mix of stream types by choosign whether to cancel or pause as
  appropriate.