### PR TITLE
Fix asyncWhere for broadcast streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.0.6
 
 - Bug Fix: Some transformers did not correctly add data to all listeners on
-  broadcast streams. Fixed for `throttle`, `debounce`, and `audit`.
+  broadcast streams. Fixed for `throttle`, `debounce`, `asyncWhere` and `audit`.
 - Bug Fix: Only call the `tap` data callback once per event rather than once per
   listener.
 - Bug Fix: Allow canceling and re-listening to broadcast streams after a

--- a/lib/src/async_where.dart
+++ b/lib/src/async_where.dart
@@ -3,11 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
+import 'from_handlers.dart';
+
 /// Like [Stream.where] but allows the [test] to return a [Future].
 StreamTransformer<T, T> asyncWhere<T>(FutureOr<bool> test(T element)) {
   var valuesWaiting = 0;
   var sourceDone = false;
-  return new StreamTransformer<T, T>.fromHandlers(handleData: (element, sink) {
+  return fromHandlers(handleData: (element, sink) {
     valuesWaiting++;
     () async {
       if (await test(element)) sink.add(element);


### PR DESCRIPTION
Previous implementation may have failed to send onDone for some
listeners since each listener would increment `valuesWaiting` and only
the last listener would decrement it back to zero. There were also
potential bugs if the predicate was non-deterministic.