### PR TITLE
Add fromBind to replace direct StreamTransformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.7
+
+- Bug Fix: Streams produces with `scan` and `switchMap` now correctly report
+  `isBroadcast`.
+
 ## 0.0.6
 
 - Bug Fix: Some transformers did not correctly add data to all listeners on

--- a/lib/src/bind.dart
+++ b/lib/src/bind.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+
+typedef Stream<T> Bind<S, T>(Stream<S> values);
+
+StreamTransformer<S, T> fromBind<S, T>(Bind<S, T> bindFn) =>
+    new _StreamTransformer(bindFn);
+
+class _StreamTransformer<S, T> implements StreamTransformer<S, T> {
+  final Bind<S, T> _bind;
+
+  _StreamTransformer(this._bind);
+
+  @override
+  Stream<T> bind(Stream<S> values) => _bind(values);
+}

--- a/lib/src/bind.dart
+++ b/lib/src/bind.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 
+/// Matches [StreamTransformer.bind].
 typedef Stream<T> Bind<S, T>(Stream<S> values);
 
+/// Creates a [StreamTransformer] which overrides [StreamTransformer.bind] to
+/// [bindFn].
 StreamTransformer<S, T> fromBind<S, T>(Bind<S, T> bindFn) =>
     new _StreamTransformer(bindFn);
 

--- a/lib/src/bind.dart
+++ b/lib/src/bind.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 /// Matches [StreamTransformer.bind].

--- a/lib/src/scan.dart
+++ b/lib/src/scan.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
+import 'bind.dart';
+
 /// Scan is like fold, but instead of producing a single value it yields
 /// each intermediate accumulation.
 StreamTransformer<S, T> scan<S, T>(
         T initialValue, T combine(T previousValue, S element)) =>
-    new StreamTransformer<S, T>((stream, cancelOnError) {
+    fromBind((stream) {
       T accumulated = initialValue;
-      return stream
-          .map((value) => accumulated = combine(accumulated, value))
-          .listen(null, cancelOnError: cancelOnError);
+      return stream.map((value) => accumulated = combine(accumulated, value));
     });

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
+import 'bind.dart';
+
 /// Maps events to a Stream and emits values from the most recently created
 /// Stream.
 ///
@@ -12,10 +14,7 @@ import 'dart:async';
 /// If the source stream is a broadcast stream, the result stream will be as
 /// well, regardless of the types of the streams produced by [map].
 StreamTransformer<S, T> switchMap<S, T>(Stream<T> map(S event)) =>
-    new StreamTransformer((stream, cancelOnError) => stream
-        .map(map)
-        .transform(switchLatest())
-        .listen(null, cancelOnError: cancelOnError));
+    fromBind((stream) => stream.map(map).transform(switchLatest()));
 
 /// Emits values from the most recently emitted Stream.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 author: Dart Team <misc@dartlang.org>
 homepage: https://www.github.com/dart-lang/stream_transform
-version: 0.0.6
+version: 0.0.7-dev
 
 environment:
   sdk: ">=1.22.0 <2.0.0"

--- a/test/scan_test.dart
+++ b/test/scan_test.dart
@@ -13,5 +13,13 @@ void main() {
 
       expect(result, [1, 3, 6, 10]);
     });
+
+    test('can create a broadcast stream', () async {
+      var source = new StreamController.broadcast();
+
+      var transformed = source.stream.transform(scan(null, null));
+
+      expect(transformed.isBroadcast, true);
+    });
   });
 }

--- a/test/switch_test.dart
+++ b/test/switch_test.dart
@@ -136,6 +136,7 @@ void main() {
       await new Future(() {});
       outer.add([4, 5, 6]);
       await new Future(() {});
+      expect(values, [1, 2, 3, 4, 5, 6]);
     });
 
     test('can create a broadcast stream', () async {

--- a/test/switch_test.dart
+++ b/test/switch_test.dart
@@ -136,7 +136,14 @@ void main() {
       await new Future(() {});
       outer.add([4, 5, 6]);
       await new Future(() {});
-      expect(values, [1, 2, 3, 4, 5, 6]);
+    });
+
+    test('can create a broadcast stream', () async {
+      var outer = new StreamController.broadcast();
+
+      var transformed = outer.stream.transform(switchMap(null));
+
+      expect(transformed.isBroadcast, true);
     });
   });
 }


### PR DESCRIPTION
Fixes dart-lang/tools#1756

`new StreamTransformer(onListen)` produces a Stream which can not know
whether it is a Broadcast stream. The `bind` method can more directly
express the intent of these transformers but adding a class is a lot of
boilerplate. Add fromBind to handle these cses.