### PR TITLE
Updates for Dart 2.0 core library changes (wave 2.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: dart
 sudo: false
 dart:
   - dev
-  - stable
-  - 1.22.1
 cache:
   directories:
     - $HOME/.pub-cache
@@ -14,9 +12,3 @@ dart_task:
   - dartfmt
   - dartanalyzer
   - dartanalyzer: --no-strong .
-matrix:
-  exclude:
-    - dart: 1.22.1
-      dart_task: dartfmt
-    - dart: 1.22.1
-      dart_task: dartanalyzer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.10
+
+- Updates to support Dart 2.0 core library changes (wave
+  2.2). See [issue 31847][sdk#31847] for details.
+  
+  [sdk#31847]: https://github.com/dart-lang/sdk/issues/31847
+
 ## 0.0.9
 
 - Add `asyncMapBuffer`.

--- a/lib/src/bind.dart
+++ b/lib/src/bind.dart
@@ -12,7 +12,7 @@ typedef Stream<T> Bind<S, T>(Stream<S> values);
 StreamTransformer<S, T> fromBind<S, T>(Bind<S, T> bindFn) =>
     new _StreamTransformer(bindFn);
 
-class _StreamTransformer<S, T> implements StreamTransformer<S, T> {
+class _StreamTransformer<S, T> extends StreamTransformerBase<S, T> {
   final Bind<S, T> _bind;
 
   _StreamTransformer(this._bind);

--- a/lib/src/buffer.dart
+++ b/lib/src/buffer.dart
@@ -24,7 +24,7 @@ StreamTransformer<T, List<T>> buffer<T>(Stream trigger) =>
 ///
 /// Errors from the source stream or the trigger are immediately forwarded to
 /// the output.
-class _Buffer<T> implements StreamTransformer<T, List<T>> {
+class _Buffer<T> extends StreamTransformerBase<T, List<T>> {
   final Stream _trigger;
 
   _Buffer(this._trigger);

--- a/lib/src/concat.dart
+++ b/lib/src/concat.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 /// buffered.
 StreamTransformer<T, T> concat<T>(Stream<T> next) => new _Concat<T>(next);
 
-class _Concat<T> implements StreamTransformer<T, T> {
+class _Concat<T> extends StreamTransformerBase<T, T> {
   final Stream<T> _next;
 
   _Concat(this._next);

--- a/lib/src/from_handlers.dart
+++ b/lib/src/from_handlers.dart
@@ -20,7 +20,7 @@ StreamTransformer<S, T> fromHandlers<S, T>(
         handleError: handleError,
         handleDone: handleDone);
 
-class _StreamTransformer<S, T> implements StreamTransformer<S, T> {
+class _StreamTransformer<S, T> extends StreamTransformerBase<S, T> {
   final HandleData<S, T> _handleData;
   final HandleDone<T> _handleDone;
   final HandleError<T> _handleError;

--- a/lib/src/merge.dart
+++ b/lib/src/merge.dart
@@ -21,7 +21,7 @@ StreamTransformer<T, T> merge<T>(Stream<T> other) => new _Merge<T>([other]);
 StreamTransformer<T, T> mergeAll<T>(List<Stream<T>> others) =>
     new _Merge<T>(others);
 
-class _Merge<T> implements StreamTransformer<T, T> {
+class _Merge<T> extends StreamTransformerBase<T, T> {
   final List<Stream<T>> _others;
 
   _Merge(this._others);

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -26,7 +26,7 @@ StreamTransformer<S, T> switchMap<S, T>(Stream<T> map(S event)) =>
 StreamTransformer<Stream<T>, T> switchLatest<T>() =>
     new _SwitchTransformer<T>();
 
-class _SwitchTransformer<T> implements StreamTransformer<Stream<T>, T> {
+class _SwitchTransformer<T> extends StreamTransformerBase<Stream<T>, T> {
   const _SwitchTransformer();
 
   @override

--- a/lib/src/take_until.dart
+++ b/lib/src/take_until.dart
@@ -12,7 +12,7 @@ import 'dart:async';
 /// a subscription immediately stops values.
 StreamTransformer<T, T> takeUntil<T>(Future trigger) => new _TakeUntil(trigger);
 
-class _TakeUntil<T> implements StreamTransformer<T, T> {
+class _TakeUntil<T> extends StreamTransformerBase<T, T> {
   final Future _trigger;
 
   _TakeUntil(this._trigger);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,10 +2,10 @@ name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 author: Dart Team <misc@dartlang.org>
 homepage: https://www.github.com/dart-lang/stream_transform
-version: 0.0.10-dev
+version: 0.0.10
 
 environment:
-  sdk: ">=1.22.0 <2.0.0"
+  sdk: ">=2.0.0-dev.20.0 <2.0.0"
 
 dev_dependencies:
   test: ^0.12.20+13


### PR DESCRIPTION
Make some classes extend StreamTransformerBase instead of implement StreamTransformer.

