### PR TITLE
Explicitly handle null callback for tap

### DIFF
--- a/lib/src/tap.dart
+++ b/lib/src/tap.dart
@@ -8,16 +8,25 @@ import 'from_handlers.dart';
 /// Taps into a Stream to allow additional handling on a single-subscriber
 /// stream without first wrapping as a broadcast stream.
 ///
-/// The callback will be called with every value from the stream before it is
-/// forwarded to listeners on the stream. Errors from the callbacks are ignored.
+/// The [onValue] callback will be called with every value from the original
+/// stream before it is forwarded to listeners on the resulting stream. May be
+/// null if only [onError] or [onDone] callbacks are needed.
 ///
-/// The tapped stream may not emit any values until the result stream has a
-/// listener, and may be canceled only by the listener.
-StreamTransformer<T, T> tap<T>(void fn(T value),
+/// The [onError] callback will be called with every error from the original
+/// stream before it is forwarded to listeners on the resulting stream.
+///
+/// The [onDone] callback will be called after the original stream closes and
+/// before the resulting stream is closed.
+///
+/// Errors from any of the callbacks are ignored.
+///
+/// The callbacks may not be called unil the tapped stream has a listener, and
+/// may not be called after the listener has canceled the subscription.
+StreamTransformer<T, T> tap<T>(void onValue(T value),
         {void onError(error, stackTrace), void onDone()}) =>
     fromHandlers(handleData: (value, sink) {
       try {
-        fn(value);
+        onValue?.call(value);
       } catch (_) {/*Ignore*/}
       sink.add(value);
     }, handleError: (error, stackTrace, sink) {

--- a/lib/src/tap.dart
+++ b/lib/src/tap.dart
@@ -20,7 +20,7 @@ import 'from_handlers.dart';
 ///
 /// Errors from any of the callbacks are ignored.
 ///
-/// The callbacks may not be called unil the tapped stream has a listener, and
+/// The callbacks may not be called until the tapped stream has a listener, and
 /// may not be called after the listener has canceled the subscription.
 StreamTransformer<T, T> tap<T>(void onValue(T value),
         {void onError(error, stackTrace), void onDone()}) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 author: Dart Team <misc@dartlang.org>
 homepage: https://www.github.com/dart-lang/stream_transform
-version: 0.0.11
+version: 0.0.12-dev
 
 environment:
   sdk: ">=2.0.0-dev.20.0 <2.0.0"

--- a/test/tap_test.dart
+++ b/test/tap_test.dart
@@ -113,4 +113,9 @@ void main() {
     expect(emittedValues1, [1]);
     expect(emittedValues2, [1]);
   });
+
+  test('allows null callback', () async {
+    var stream = new Stream.fromIterable([1, 2, 3]);
+    await stream.transform(tap(null)).last;
+  });
 }


### PR DESCRIPTION
This does not change visible behavior since a null callback would have
previously been an ignored exception.

Rename the argument to `onValue` for consistency and expand the doc
comment.