### PR TITLE
Forward errors throw during `asyncWhere`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.14
+
+- `asyncWhere` will now forward exceptions thrown by the callback through the
+  result Stream.
+
 ## 0.0.13
 
 - `mergeAll` now accepts an `Iterable<Stream>` instead of only `List<Stream>`.

--- a/test/async_where_test.dart
+++ b/test/async_where_test.dart
@@ -66,4 +66,20 @@ void main() {
     expect(firstDone, true);
     expect(secondDone, true);
   });
+
+  test('forwards errors emitted by the test callback', () async {
+    var errors = [];
+    var emitted = [];
+    var values = new Stream.fromIterable([1, 2, 3, 4]);
+    var filtered = values.transform(asyncWhere((e) async {
+      await new Future(() {});
+      if (e.isEven) throw new Exception('$e');
+      return true;
+    }));
+    var done = new Completer();
+    filtered.listen(emitted.add, onError: errors.add, onDone: done.complete);
+    await done.future;
+    expect(emitted, [1, 3]);
+    expect(errors.map((e) => '$e'), ['Exception: 2', 'Exception: 4']);
+  });
 }


### PR DESCRIPTION
- Add a try/catch and a test for the new behavior.
- Update the Doc comment with more details on the behavior.