### PR TITLE
Stop running --no-strong analyzer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,5 @@ cache:
 dart_task:
   - test
   - test -p chrome
-  - test -p firefox
   - dartfmt
   - dartanalyzer
-  - dartanalyzer: --no-strong .


### PR DESCRIPTION
With Dart 2 Strong mode is the only analysis we care about. Also stop
running extra tests on firefox.