### PR TITLE
Add `combineLatest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   behavior changes for synchronous callbacks. **Potential breaking change** In
   the unlikely situation where `scan` was used to produce a `Stream<Future>`
   inference may now fail and require explicit generic type arguments.
+- Add `combineLatest`.
 
 ## 0.0.15
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ the most recent value.
 Collects values from a source stream until a `trigger` stream fires and the
 collected values are emitted.
 
+# combineLatest
+
+Combine the most recent event from two streams through a callback and emit thre
+result.
+
 # debounce, debounceBuffer
 
 Prevents a source stream from emitting too frequently by dropping or collecting

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ collected values are emitted.
 
 # combineLatest
 
-Combine the most recent event from two streams through a callback and emit thre
+Combine the most recent event from two streams through a callback and emit the
 result.
 
 # debounce, debounceBuffer

--- a/lib/src/combine_latest.dart
+++ b/lib/src/combine_latest.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+/// Combine the latest value from the source stream with the latest value from
+/// [combineWith] using [combine].
+///
+/// No event will be emitted from the result stream until both the source stream
+/// and [combineWith] have each emitted at least one event. The result stream
+/// will not close until both the source stream and [combineWith] have closed.
+/// Errors throw by [combine], along with any errors on the source stream or
+/// [combineWith], are forwarded to the result stream.
+///
+/// If the source stream is a broadcast stream, the result stream will be as
+/// well, regardless of [combineWith]'s type. If a single subscription stream is
+/// merged into a broadcast stream it may never be canceled.
+StreamTransformer<S, R> combineLatest<S, T, R>(
+        Stream<T> combineWith, FutureOr<R> Function(S, T) combine) =>
+    _CombineLatest(combineWith, combine);
+
+class _CombineLatest<S, T, R> extends StreamTransformerBase<S, R> {
+  final Stream<T> _other;
+  final FutureOr<R> Function(S, T) _combine;
+
+  _CombineLatest(this._other, this._combine);
+
+  @override
+  Stream<R> bind(Stream<S> source) {
+    final controller = source.isBroadcast
+        ? StreamController<R>.broadcast(sync: true)
+        : StreamController<R>(sync: true);
+
+    final other = (source.isBroadcast && !_other.isBroadcast)
+        ? _other.asBroadcastStream()
+        : _other;
+
+    StreamSubscription sourceSubscription;
+    StreamSubscription otherSubscription;
+
+    var sourceDone = false;
+    var otherDone = false;
+
+    S latestSource;
+    T latestOther;
+
+    var sourceStarted = false;
+    var otherStarted = false;
+
+    void emitCombined() {
+      if (!sourceStarted || !otherStarted) return;
+      FutureOr<R> result;
+      try {
+        result = _combine(latestSource, latestOther);
+      } catch (e, s) {
+        controller.addError(e, s);
+        return;
+      }
+      if (result is Future<R>) {
+        result
+            .then(controller.add, onError: controller.addError)
+            .whenComplete(() {
+          sourceSubscription.resume();
+          otherSubscription.resume();
+        });
+      } else {
+        controller.add(result as R);
+      }
+    }
+
+    controller.onListen = () {
+      if (sourceSubscription != null) return;
+      sourceSubscription = source.listen(
+          (s) {
+            sourceStarted = true;
+            latestSource = s;
+            emitCombined();
+          },
+          onError: controller.addError,
+          onDone: () {
+            sourceDone = true;
+            if (otherDone) controller.close();
+          });
+      otherSubscription = other.listen(
+          (o) {
+            otherStarted = true;
+            latestOther = o;
+            emitCombined();
+          },
+          onError: controller.addError,
+          onDone: () {
+            otherDone = true;
+            if (sourceDone) controller.close();
+          });
+      if (!source.isBroadcast) {
+        controller
+          ..onPause = () {
+            sourceSubscription.pause();
+            otherSubscription.pause();
+          }
+          ..onResume = () {
+            sourceSubscription.resume();
+            otherSubscription.resume();
+          };
+      }
+      controller.onCancel = () async {
+        var cancelSource = sourceSubscription.cancel();
+        var cancelOther = otherSubscription.cancel();
+        sourceSubscription = null;
+        otherSubscription = null;
+
+        await cancelSource;
+        await cancelOther;
+      };
+    };
+    return controller.stream;
+  }
+}

--- a/lib/src/combine_latest.dart
+++ b/lib/src/combine_latest.dart
@@ -5,11 +5,11 @@
 import 'dart:async';
 
 /// Combine the latest value from the source stream with the latest value from
-/// [combineWith] using [combine].
+/// [other] using [combine].
 ///
 /// No event will be emitted from the result stream until both the source stream
-/// and [combineWith] have each emitted at least one event. Once both streams
-/// have emitted at least one event, the result stream will emit any time either
+/// and [other] have each emitted at least one event. Once both streams have
+/// emitted at least one event, the result stream will emit any time either
 /// input stream emits.
 ///
 /// For example:
@@ -22,18 +22,18 @@ import 'dart:async';
 ///   result:
 ///     ------5--7
 ///
-/// The result stream will not close until both the source stream and
-/// [combineWith] have closed.
+/// The result stream will not close until both the source stream and [other]
+/// have closed.
 ///
 /// Errors thrown by [combine], along with any errors on the source stream or
-/// [combineWith], are forwarded to the result stream.
+/// [other], are forwarded to the result stream.
 ///
 /// If the source stream is a broadcast stream, the result stream will be as
-/// well, regardless of [combineWith]'s type. If a single subscription stream is
+/// well, regardless of [other]'s type. If a single subscription stream is
 /// combined with a broadcast stream it may never be canceled.
 StreamTransformer<S, R> combineLatest<S, T, R>(
-        Stream<T> combineWith, FutureOr<R> Function(S, T) combine) =>
-    _CombineLatest(combineWith, combine);
+        Stream<T> other, FutureOr<R> Function(S, T) combine) =>
+    _CombineLatest(other, combine);
 
 class _CombineLatest<S, T, R> extends StreamTransformerBase<S, R> {
   final Stream<T> _other;

--- a/lib/src/combine_latest.dart
+++ b/lib/src/combine_latest.dart
@@ -80,7 +80,13 @@ class _CombineLatest<S, T, R> extends StreamTransformerBase<S, R> {
           onError: controller.addError,
           onDone: () {
             sourceDone = true;
-            if (otherDone) controller.close();
+            if (otherDone) {
+              controller.close();
+            } else if (!sourceStarted) {
+              // Nothing can ever be emitted
+              otherSubscription.cancel();
+              controller.close();
+            }
           });
       otherSubscription = other.listen(
           (o) {
@@ -91,7 +97,13 @@ class _CombineLatest<S, T, R> extends StreamTransformerBase<S, R> {
           onError: controller.addError,
           onDone: () {
             otherDone = true;
-            if (sourceDone) controller.close();
+            if (sourceDone) {
+              controller.close();
+            } else if (!otherStarted) {
+              // Nothing can ever be emitted
+              sourceSubscription.cancel();
+              controller.close();
+            }
           });
       if (!source.isBroadcast) {
         controller

--- a/lib/src/combine_latest.dart
+++ b/lib/src/combine_latest.dart
@@ -116,14 +116,12 @@ class _CombineLatest<S, T, R> extends StreamTransformerBase<S, R> {
             otherSubscription.resume();
           };
       }
-      controller.onCancel = () async {
+      controller.onCancel = () {
         var cancelSource = sourceSubscription.cancel();
         var cancelOther = otherSubscription.cancel();
         sourceSubscription = null;
         otherSubscription = null;
-
-        await cancelSource;
-        await cancelOther;
+        return Future.wait([cancelSource, cancelOther]);
       };
     };
     return controller.stream;

--- a/lib/stream_transform.dart
+++ b/lib/stream_transform.dart
@@ -7,6 +7,7 @@ export 'src/async_where.dart';
 export 'src/audit.dart';
 export 'src/buffer.dart';
 export 'src/chain_transformers.dart';
+export 'src/combine_latest.dart';
 export 'src/concat.dart';
 export 'src/concurrent_async_map.dart';
 export 'src/debounce.dart';

--- a/test/combine_latest_test.dart
+++ b/test/combine_latest_test.dart
@@ -52,12 +52,30 @@ void main() {
           .transform(combineLatest(combineWith.stream, sum))
           .listen(null, onDone: () => done = true);
 
+      source.add(1);
+
       await source.close();
       await Future(() {});
       expect(done, false);
 
       await combineWith.close();
       await Future(() {});
+      expect(done, true);
+    });
+
+    test('ends if a Stream closes without ever emitting a value', () async {
+      var source = StreamController<int>();
+      var combineWith = Stream<int>.empty();
+
+      int sum(int a, int b) => a + b;
+
+      var done = false;
+      source.stream
+          .transform(combineLatest(combineWith, sum))
+          .listen(null, onDone: () => done = true);
+
+      await Future(() {});
+      // Nothing can ever be emitted on the result, may as well close.
       expect(done, true);
     });
 

--- a/test/combine_latest_test.dart
+++ b/test/combine_latest_test.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:pedantic/pedantic.dart';
+import 'package:test/test.dart';
+
+import 'package:stream_transform/stream_transform.dart';
+
+void main() {
+  group('combineLatest', () {
+    test('flows through combine callback', () async {
+      var source = StreamController<int>();
+      var combineWith = StreamController<int>();
+      int sum(int a, int b) => a + b;
+
+      var results = <int>[];
+      unawaited(source.stream
+          .transform(combineLatest(combineWith.stream, sum))
+          .forEach(results.add));
+
+      source.add(1);
+      await Future(() {});
+      expect(results, isEmpty);
+
+      combineWith.add(2);
+      await Future(() {});
+      expect(results, [3]);
+
+      source.add(3);
+      await Future(() {});
+      expect(results, [3, 5]);
+
+      source.add(4);
+      await Future(() {});
+      expect(results, [3, 5, 6]);
+
+      combineWith.add(5);
+      await Future(() {});
+      expect(results, [3, 5, 6, 9]);
+    });
+
+    test('ends after both streams have ended', () async {
+      var source = StreamController<int>();
+      var combineWith = StreamController<int>();
+      int sum(int a, int b) => a + b;
+
+      var done = false;
+      source.stream
+          .transform(combineLatest(combineWith.stream, sum))
+          .listen(null, onDone: () => done = true);
+
+      await source.close();
+      await Future(() {});
+      expect(done, false);
+
+      await combineWith.close();
+      await Future(() {});
+      expect(done, true);
+    });
+
+    test('forwards errors', () async {
+      var source = StreamController<int>();
+      var combineWith = StreamController<int>();
+      int sum(int a, int b) => throw _NumberedException(3);
+
+      var errors = [];
+      source.stream
+          .transform(combineLatest(combineWith.stream, sum))
+          .listen(null, onError: errors.add);
+
+      source.addError(_NumberedException(1));
+      combineWith.addError(_NumberedException(2));
+
+      source.add(1);
+      combineWith.add(2);
+
+      await Future(() {});
+
+      expect(errors, [_isException(1), _isException(2), _isException(3)]);
+    });
+
+    group('broadcast source', () {
+      test('can cancel and relisten to broadcast stream', () async {
+        var source = StreamController<int>.broadcast();
+        var combineWith = StreamController<int>();
+        int combine(int a, int b) => a + b;
+
+        var emittedValues = <int>[];
+        var transformed =
+            source.stream.transform(combineLatest(combineWith.stream, combine));
+
+        var subscription = transformed.listen(emittedValues.add);
+
+        source.add(1);
+        combineWith.add(2);
+        await Future(() {});
+        expect(emittedValues, [3]);
+
+        await subscription.cancel();
+
+        subscription = transformed.listen(emittedValues.add);
+        source.add(3);
+        await Future(() {});
+        expect(emittedValues, [3, 5]);
+      });
+    });
+  });
+}
+
+class _NumberedException implements Exception {
+  final int id;
+  _NumberedException(this.id);
+}
+
+Matcher _isException(int id) =>
+    TypeMatcher<_NumberedException>().having((n) => n.id, 'id', id);


### PR DESCRIPTION
Closes dart-lang/tools#1762

Uses an manual `StreamTransformer` implementation based closely on the
`merge` implementation. This can't be implemented on top of
`fromHandlers` or normal stream methods because the events emitted
aren't triggered by a single source.