### PR TITLE
Change onListen bailouts to asserts

### DIFF
--- a/lib/src/buffer.dart
+++ b/lib/src/buffer.dart
@@ -86,7 +86,7 @@ class _Buffer<T> extends StreamTransformerBase<T, List<T>> {
     }
 
     controller.onListen = () {
-      if (valueSub != null) return;
+      assert(valueSub == null);
       valueSub = values.listen(onValue,
           onError: controller.addError, onDone: onValuesDone);
       if (triggerSub != null) {

--- a/lib/src/combine_latest_all.dart
+++ b/lib/src/combine_latest_all.dart
@@ -63,7 +63,7 @@ class _CombineLatestAll<T> extends StreamTransformerBase<T, List<T>> {
     List<StreamSubscription> subscriptions;
 
     controller.onListen = () {
-      if (subscriptions != null) return;
+      assert(subscriptions == null);
 
       final latestData = List<T>(allStreams.length);
       final hasEmitted = <int>{};

--- a/lib/src/followed_by.dart
+++ b/lib/src/followed_by.dart
@@ -60,7 +60,7 @@ class _FollowedBy<T> extends StreamTransformerBase<T, T> {
     currentDoneHandler = onFirstDone;
 
     controller.onListen = () {
-      if (subscription != null) return;
+      assert(subscription == null);
       listen();
       if (!first.isBroadcast) {
         controller.onPause = () {

--- a/lib/src/from_handlers.dart
+++ b/lib/src/from_handlers.dart
@@ -54,7 +54,7 @@ class _StreamTransformer<S, T> extends StreamTransformerBase<S, T> {
 
     StreamSubscription<S> subscription;
     controller.onListen = () {
-      if (subscription != null) return;
+      assert(subscription == null);
       var valuesDone = false;
       subscription = values.listen((value) => _handleData(value, controller),
           onError: (error, StackTrace stackTrace) {

--- a/lib/src/merge.dart
+++ b/lib/src/merge.dart
@@ -42,7 +42,7 @@ class _Merge<T> extends StreamTransformerBase<T, T> {
     List<StreamSubscription> subscriptions;
 
     controller.onListen = () {
-      if (subscriptions != null) return;
+      assert(subscriptions == null);
       var activeStreamCount = 0;
       subscriptions = allStreams.map((stream) {
         activeStreamCount++;

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -38,7 +38,7 @@ class _SwitchTransformer<T> extends StreamTransformerBase<Stream<T>, T> {
     StreamSubscription<Stream<T>> outerSubscription;
 
     controller.onListen = () {
-      if (outerSubscription != null) return;
+      assert(outerSubscription == null);
 
       StreamSubscription<T> innerSubscription;
       var outerStreamDone = false;

--- a/lib/src/where_type.dart
+++ b/lib/src/where_type.dart
@@ -30,7 +30,7 @@ class _WhereType<R> extends StreamTransformerBase<Null, R> {
 
     StreamSubscription<Object> subscription;
     controller.onListen = () {
-      if (subscription != null) return;
+      assert(subscription == null);
       subscription = source.listen(
           (value) {
             if (value is R) controller.add(value);


### PR DESCRIPTION
These transformers had a check that should never be true because the
behavior of the `StreamController` should prevent `onListen` from being
called multiple times while there is at least one active listener.