### PR TITLE
Explicitly test on earliest supported stable SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
   only: [master]
 dart:
   - dev
-  - stable
+  - 2.2.0
 cache:
   directories:
     - $HOME/.pub-cache


### PR DESCRIPTION
This way when a new stable is released it won't stop the tests on a
supported SDK version.