### PR TITLE
Make tap's onError arguments have specific types

### DIFF
--- a/lib/src/tap.dart
+++ b/lib/src/tap.dart
@@ -22,8 +22,8 @@ import 'from_handlers.dart';
 ///
 /// The callbacks may not be called until the tapped stream has a listener, and
 /// may not be called after the listener has canceled the subscription.
-StreamTransformer<T, T> tap<T>(void onValue(T value),
-        {void onError(error, stackTrace), void onDone()}) =>
+StreamTransformer<T, T> tap<T>(void Function(T) onValue,
+        {void Function(Object, StackTrace) onError, void Function() onDone}) =>
     fromHandlers(handleData: (value, sink) {
       try {
         onValue?.call(value);


### PR DESCRIPTION
Currently `onError` has type `void Function(dynamic, dynamic)`.

This causes a problem with something like:

```
void myOnError(Object error, StackTrace stackTrace) {}
stream.transform(tap(null, onError: myOnError)).listen(null);
```

As that causes an error:

```
type '(Object, StackTrace) => void' is not a subtype of type '(dynamic, dynamic) => void'
```

Note that `(dynamic, dynamic) => void` is a subtype of `(Object, StackTrace) => void`, so any function that can be passed to the old version can also be passed to the new one.