### PR TITLE
Enable and fix strict-raw-types checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.18
+
+- Internal cleanup. Passed "trigger" streams or futures now allow `<void>`
+  generic type rather than an implicit `dynamic>`
+
 ## 0.0.17
 
 - Add concrete types to the `onError` callback in `tap`.
@@ -47,7 +52,7 @@
 
 - Updates to support Dart 2.0 core library changes (wave
   2.2). See [issue 31847][sdk#31847] for details.
-  
+
   [sdk#31847]: https://github.com/dart-lang/sdk/issues/31847
 
 ## 0.0.9

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,6 +2,8 @@ include: package:pedantic/analysis_options.yaml
 analyzer:
   strong-mode:
     implicit-casts: false
+  language:
+    strict-raw-types: true
   errors:
     todo: ignore
     dead_code: error

--- a/lib/src/buffer.dart
+++ b/lib/src/buffer.dart
@@ -12,7 +12,8 @@ import 'dart:async';
 ///
 /// Errors from the source stream or the trigger are immediately forwarded to
 /// the output.
-StreamTransformer<T, List<T>> buffer<T>(Stream trigger) => _Buffer<T>(trigger);
+StreamTransformer<T, List<T>> buffer<T>(Stream<void> trigger) =>
+    _Buffer<T>(trigger);
 
 /// A StreamTransformer which aggregates values and emits when it sees a value
 /// on [_trigger].
@@ -24,7 +25,7 @@ StreamTransformer<T, List<T>> buffer<T>(Stream trigger) => _Buffer<T>(trigger);
 /// Errors from the source stream or the trigger are immediately forwarded to
 /// the output.
 class _Buffer<T> extends StreamTransformerBase<T, List<T>> {
-  final Stream _trigger;
+  final Stream<void> _trigger;
 
   _Buffer(this._trigger);
 
@@ -38,8 +39,8 @@ class _Buffer<T> extends StreamTransformerBase<T, List<T>> {
     var waitingForTrigger = true;
     var isTriggerDone = false;
     var isValueDone = false;
-    StreamSubscription valueSub;
-    StreamSubscription triggerSub;
+    StreamSubscription<T> valueSub;
+    StreamSubscription<void> triggerSub;
 
     emit() {
       controller.add(currentResults);
@@ -107,7 +108,7 @@ class _Buffer<T> extends StreamTransformerBase<T, List<T>> {
           };
       }
       controller.onCancel = () {
-        var toCancel = <StreamSubscription>[];
+        var toCancel = <StreamSubscription<void>>[];
         if (!isValueDone) toCancel.add(valueSub);
         valueSub = null;
         if (_trigger.isBroadcast || !values.isBroadcast) {

--- a/lib/src/combine_latest.dart
+++ b/lib/src/combine_latest.dart
@@ -51,8 +51,8 @@ class _CombineLatest<S, T, R> extends StreamTransformerBase<S, R> {
         ? _other.asBroadcastStream()
         : _other;
 
-    StreamSubscription sourceSubscription;
-    StreamSubscription otherSubscription;
+    StreamSubscription<S> sourceSubscription;
+    StreamSubscription<T> otherSubscription;
 
     var sourceDone = false;
     var otherDone = false;

--- a/lib/src/combine_latest_all.dart
+++ b/lib/src/combine_latest_all.dart
@@ -60,7 +60,7 @@ class _CombineLatestAll<T> extends StreamTransformerBase<T, List<T>> {
           .toList();
     }
 
-    List<StreamSubscription> subscriptions;
+    List<StreamSubscription<T>> subscriptions;
 
     controller.onListen = () {
       assert(subscriptions == null);

--- a/lib/src/followed_by.dart
+++ b/lib/src/followed_by.dart
@@ -33,7 +33,7 @@ class _FollowedBy<T> extends StreamTransformerBase<T, T> {
         ? _next.asBroadcastStream()
         : _next;
 
-    StreamSubscription subscription;
+    StreamSubscription<T> subscription;
     var currentStream = first;
     var firstDone = false;
     var secondDone = false;

--- a/lib/src/merge.dart
+++ b/lib/src/merge.dart
@@ -39,7 +39,7 @@ class _Merge<T> extends StreamTransformerBase<T, T> {
           .toList();
     }
 
-    List<StreamSubscription> subscriptions;
+    List<StreamSubscription<T>> subscriptions;
 
     controller.onListen = () {
       assert(subscriptions == null);

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -69,7 +69,7 @@ class _SwitchTransformer<T> extends StreamTransformerBase<Stream<T>, T> {
           };
       }
       controller.onCancel = () {
-        var toCancel = <StreamSubscription>[];
+        var toCancel = <StreamSubscription<void>>[];
         if (!outerStreamDone) toCancel.add(outerSubscription);
         if (innerSubscription != null) {
           toCancel.add(innerSubscription);

--- a/lib/src/take_until.dart
+++ b/lib/src/take_until.dart
@@ -10,10 +10,11 @@ import 'dart:async';
 /// which are emitted before the trigger, but have further asynchronous delays
 /// in transformations following the takeUtil, will still go through. Cancelling
 /// a subscription immediately stops values.
-StreamTransformer<T, T> takeUntil<T>(Future trigger) => _TakeUntil(trigger);
+StreamTransformer<T, T> takeUntil<T>(Future<void> trigger) =>
+    _TakeUntil(trigger);
 
 class _TakeUntil<T> extends StreamTransformerBase<T, T> {
-  final Future _trigger;
+  final Future<void> _trigger;
 
   _TakeUntil(this._trigger);
 
@@ -23,7 +24,7 @@ class _TakeUntil<T> extends StreamTransformerBase<T, T> {
         ? StreamController<T>.broadcast(sync: true)
         : StreamController<T>(sync: true);
 
-    StreamSubscription subscription;
+    StreamSubscription<T> subscription;
     var isDone = false;
     _trigger.then((_) {
       if (isDone) return;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 author: Dart Team <misc@dartlang.org>
 homepage: https://www.github.com/dart-lang/stream_transform
-version: 0.0.17
+version: 0.0.18
 
 environment:
   sdk: ">=2.2.0 <3.0.0"

--- a/test/async_map_buffer_test.dart
+++ b/test/async_map_buffer_test.dart
@@ -8,25 +8,23 @@ import 'package:test/test.dart';
 
 import 'package:stream_transform/stream_transform.dart';
 
+import 'utils.dart';
+
 void main() {
-  var streamTypes = {
-    'single subscription': () => StreamController(),
-    'broadcast': () => StreamController.broadcast()
-  };
-  StreamController values;
-  List emittedValues;
+  StreamController<int> values;
+  List<String> emittedValues;
   bool valuesCanceled;
   bool isDone;
-  List errors;
-  Stream transformed;
-  StreamSubscription subscription;
+  List<String> errors;
+  Stream<String> transformed;
+  StreamSubscription<String> subscription;
 
-  Completer finishWork;
-  List workArgument;
+  Completer<String> finishWork;
+  List<int> workArgument;
 
   /// Represents the async `convert` function and asserts that is is only called
   /// after the previous iteration has completed.
-  Future work(List values) {
+  Future<String> work(List<int> values) {
     expect(finishWork, isNull,
         reason: 'See $values befor previous work is complete');
     workArgument = values;
@@ -41,11 +39,11 @@ void main() {
     return finishWork.future;
   }
 
-  for (var streamType in streamTypes.keys) {
+  for (var streamType in streamTypes) {
     group('asyncMapBuffer for stream type: [$streamType]', () {
       setUp(() {
         valuesCanceled = false;
-        values = streamTypes[streamType]()
+        values = createController(streamType)
           ..onCancel = () {
             valuesCanceled = true;
           };
@@ -66,11 +64,9 @@ void main() {
         await Future(() {});
         expect(emittedValues, isEmpty);
         expect(workArgument, [1]);
-        finishWork.complete(workArgument);
+        finishWork.complete('result');
         await Future(() {});
-        expect(emittedValues, [
-          [1]
-        ]);
+        expect(emittedValues, ['result']);
       });
 
       test('buffers values while work is ongoing', () async {

--- a/test/audit_test.dart
+++ b/test/audit_test.dart
@@ -10,23 +10,19 @@ import 'package:stream_transform/stream_transform.dart';
 import 'utils.dart';
 
 void main() {
-  var streamTypes = {
-    'single subscription': () => StreamController(),
-    'broadcast': () => StreamController.broadcast()
-  };
-  for (var streamType in streamTypes.keys) {
+  for (var streamType in streamTypes) {
     group('Stream type [$streamType]', () {
-      StreamController values;
-      List emittedValues;
+      StreamController<int> values;
+      List<int> emittedValues;
       bool valuesCanceled;
       bool isDone;
-      List errors;
-      Stream transformed;
-      StreamSubscription subscription;
+      List<String> errors;
+      Stream<int> transformed;
+      StreamSubscription<int> subscription;
 
-      void setUpStreams(StreamTransformer transformer) {
+      void setUpStreams(StreamTransformer<int, int> transformer) {
         valuesCanceled = false;
-        values = streamTypes[streamType]()
+        values = createController(streamType)
           ..onCancel = () {
             valuesCanceled = true;
           };

--- a/test/buffer_test.dart
+++ b/test/buffer_test.dart
@@ -7,27 +7,25 @@ import 'package:test/test.dart';
 
 import 'package:stream_transform/stream_transform.dart';
 
+import 'utils.dart';
+
 void main() {
-  var streamTypes = {
-    'single subscription': () => StreamController(),
-    'broadcast': () => StreamController.broadcast()
-  };
-  StreamController trigger;
-  StreamController values;
-  List emittedValues;
+  StreamController<void> trigger;
+  StreamController<int> values;
+  List<List<int>> emittedValues;
   bool valuesCanceled;
   bool triggerCanceled;
   bool triggerPaused;
   bool isDone;
-  List errors;
-  Stream transformed;
-  StreamSubscription subscription;
+  List<String> errors;
+  Stream<List<int>> transformed;
+  StreamSubscription<List<int>> subscription;
 
   void setUpForStreamTypes(String triggerType, String valuesType) {
     valuesCanceled = false;
     triggerCanceled = false;
     triggerPaused = false;
-    trigger = streamTypes[triggerType]()
+    trigger = createController(triggerType)
       ..onCancel = () {
         triggerCanceled = true;
       };
@@ -36,7 +34,7 @@ void main() {
         triggerPaused = true;
       };
     }
-    values = streamTypes[valuesType]()
+    values = createController(valuesType)
       ..onCancel = () {
         valuesCanceled = true;
       };
@@ -50,8 +48,8 @@ void main() {
     });
   }
 
-  for (var triggerType in streamTypes.keys) {
-    for (var valuesType in streamTypes.keys) {
+  for (var triggerType in streamTypes) {
+    for (var valuesType in streamTypes) {
       group('Trigger type: [$triggerType], Values type: [$valuesType]', () {
         setUp(() {
           setUpForStreamTypes(triggerType, valuesType);
@@ -222,7 +220,7 @@ void main() {
     expect(triggerPaused, true);
   });
 
-  for (var triggerType in streamTypes.keys) {
+  for (var triggerType in streamTypes) {
     test('cancel and relisten with [$triggerType] trigger', () async {
       setUpForStreamTypes(triggerType, 'broadcast');
       values.add(1);

--- a/test/followd_by_test.dart
+++ b/test/followd_by_test.dart
@@ -7,35 +7,33 @@ import 'package:test/test.dart';
 
 import 'package:stream_transform/stream_transform.dart';
 
-void main() {
-  var streamTypes = {
-    'single subscription': () => StreamController(),
-    'broadcast': () => StreamController.broadcast()
-  };
-  for (var firstType in streamTypes.keys) {
-    for (var secondType in streamTypes.keys) {
-      group('followedBy [$firstType] with [$secondType]', () {
-        StreamController first;
-        StreamController second;
+import 'utils.dart';
 
-        List emittedValues;
+void main() {
+  for (var firstType in streamTypes) {
+    for (var secondType in streamTypes) {
+      group('followedBy [$firstType] with [$secondType]', () {
+        StreamController<int> first;
+        StreamController<int> second;
+
+        List<int> emittedValues;
         bool firstCanceled;
         bool secondCanceled;
         bool secondListened;
         bool isDone;
-        List errors;
-        Stream transformed;
-        StreamSubscription subscription;
+        List<String> errors;
+        Stream<int> transformed;
+        StreamSubscription<int> subscription;
 
         setUp(() async {
           firstCanceled = false;
           secondCanceled = false;
           secondListened = false;
-          first = streamTypes[firstType]()
+          first = createController(firstType)
             ..onCancel = () {
               firstCanceled = true;
             };
-          second = streamTypes[secondType]()
+          second = createController(secondType)
             ..onCancel = () {
               secondCanceled = true;
             }

--- a/test/from_handlers_test.dart
+++ b/test/from_handlers_test.dart
@@ -9,16 +9,16 @@ import 'package:test/test.dart';
 import 'package:stream_transform/src/from_handlers.dart';
 
 void main() {
-  StreamController values;
-  List emittedValues;
+  StreamController<int> values;
+  List<int> emittedValues;
   bool valuesCanceled;
   bool isDone;
-  List errors;
-  Stream transformed;
-  StreamSubscription subscription;
+  List<String> errors;
+  Stream<int> transformed;
+  StreamSubscription<int> subscription;
 
-  void setUpForController(
-      StreamController controller, StreamTransformer transformer) {
+  void setUpForController(StreamController<int> controller,
+      StreamTransformer<int, int> transformer) {
     valuesCanceled = false;
     values = controller
       ..onCancel = () {
@@ -68,10 +68,10 @@ void main() {
     });
 
     group('broadcast stream with muliple listeners', () {
-      List emittedValues2;
-      List errors2;
+      List<int> emittedValues2;
+      List<String> errors2;
       bool isDone2;
-      StreamSubscription subscription2;
+      StreamSubscription<int> subscription2;
 
       setUp(() {
         setUpForController(StreamController.broadcast(), fromHandlers());

--- a/test/scan_test.dart
+++ b/test/scan_test.dart
@@ -58,8 +58,10 @@ void main() {
             .transform(scan<int, Future<int>>(Future.value(0), sum))
             .toList();
 
-        expect(
-            result, [const TypeMatcher<Future>(), const TypeMatcher<Future>()]);
+        expect(result, [
+          const TypeMatcher<Future<void>>(),
+          const TypeMatcher<Future<void>>()
+        ]);
         expect(await Future.wait(result), [1, 3]);
       });
 

--- a/test/start_with_test.dart
+++ b/test/start_with_test.dart
@@ -8,28 +8,27 @@ import 'package:test/test.dart';
 
 import 'package:stream_transform/stream_transform.dart';
 
-void main() {
-  var streamTypes = {
-    'single subscription': () => StreamController(),
-    'broadcast': () => StreamController.broadcast()
-  };
-  StreamController values;
-  Stream transformed;
-  StreamSubscription subscription;
+import 'utils.dart';
 
-  List emittedValues;
+void main() {
+  StreamController<int> values;
+  Stream<int> transformed;
+  StreamSubscription<int> subscription;
+
+  List<int> emittedValues;
   bool isDone;
 
-  setupForStreamType(String streamType, StreamTransformer transformer) {
+  setupForStreamType(
+      String streamType, StreamTransformer<int, int> transformer) {
     emittedValues = [];
     isDone = false;
-    values = streamTypes[streamType]();
+    values = createController(streamType);
     transformed = values.stream.transform(transformer);
     subscription =
         transformed.listen(emittedValues.add, onDone: () => isDone = true);
   }
 
-  for (var streamType in streamTypes.keys) {
+  for (var streamType in streamTypes) {
     group('startWith then [$streamType]', () {
       setUp(() => setupForStreamType(streamType, startWith(1)));
 
@@ -101,11 +100,11 @@ void main() {
       }
     });
 
-    for (var startingStreamType in streamTypes.keys) {
+    for (var startingStreamType in streamTypes) {
       group('startWithStream [$startingStreamType] then [$streamType]', () {
-        StreamController starting;
+        StreamController<int> starting;
         setUp(() async {
-          starting = streamTypes[startingStreamType]();
+          starting = createController(startingStreamType);
           setupForStreamType(streamType, startWithStream(starting.stream));
         });
 

--- a/test/switch_test.dart
+++ b/test/switch_test.dart
@@ -8,42 +8,39 @@ import 'package:test/test.dart';
 
 import 'package:stream_transform/stream_transform.dart';
 
-void main() {
-  var streamTypes = {
-    'single subscription': () => StreamController(),
-    'broadcast': () => StreamController.broadcast()
-  };
-  for (var outerType in streamTypes.keys) {
-    for (var innerType in streamTypes.keys) {
-      group('Outer type: [$outerType], Inner type: [$innerType]', () {
-        StreamController first;
-        StreamController second;
-        StreamController outer;
+import 'utils.dart';
 
-        List emittedValues;
+void main() {
+  for (var outerType in streamTypes) {
+    for (var innerType in streamTypes) {
+      group('Outer type: [$outerType], Inner type: [$innerType]', () {
+        StreamController<int> first;
+        StreamController<int> second;
+        StreamController<Stream<int>> outer;
+
+        List<int> emittedValues;
         bool firstCanceled;
         bool outerCanceled;
         bool isDone;
-        List errors;
-        StreamSubscription subscription;
+        List<String> errors;
+        StreamSubscription<int> subscription;
 
         setUp(() async {
           firstCanceled = false;
           outerCanceled = false;
-          outer = streamTypes[outerType]()
+          outer = createController(outerType)
             ..onCancel = () {
               outerCanceled = true;
             };
-          first = streamTypes[innerType]()
+          first = createController(innerType)
             ..onCancel = () {
               firstCanceled = true;
             };
-          second = streamTypes[innerType]();
+          second = createController(innerType);
           emittedValues = [];
           errors = [];
           isDone = false;
           subscription = outer.stream
-              .cast<Stream>()
               .transform(switchLatest())
               .listen(emittedValues.add, onError: errors.add, onDone: () {
             isDone = true;
@@ -129,7 +126,7 @@ void main() {
 
   group('switchMap', () {
     test('uses map function', () async {
-      var outer = StreamController<List>();
+      var outer = StreamController<List<int>>();
 
       var values = [];
       outer.stream

--- a/test/take_until_test.dart
+++ b/test/take_until_test.dart
@@ -8,25 +8,23 @@ import 'package:test/test.dart';
 
 import 'package:stream_transform/stream_transform.dart';
 
+import 'utils.dart';
+
 void main() {
-  var streamTypes = {
-    'single subscription': () => StreamController(),
-    'broadcast': () => StreamController.broadcast()
-  };
-  for (var streamType in streamTypes.keys) {
+  for (var streamType in streamTypes) {
     group('takeUntil on Stream type [$streamType]', () {
-      StreamController values;
-      List emittedValues;
+      StreamController<int> values;
+      List<int> emittedValues;
       bool valuesCanceled;
       bool isDone;
-      List errors;
-      Stream transformed;
-      StreamSubscription subscription;
-      Completer closeTrigger;
+      List<String> errors;
+      Stream<int> transformed;
+      StreamSubscription<int> subscription;
+      Completer<void> closeTrigger;
 
       setUp(() {
         valuesCanceled = false;
-        values = streamTypes[streamType]()
+        values = createController(streamType)
           ..onCancel = () {
             valuesCanceled = true;
           };

--- a/test/throttle_test.dart
+++ b/test/throttle_test.dart
@@ -10,32 +10,25 @@ import 'package:stream_transform/stream_transform.dart';
 import 'utils.dart';
 
 void main() {
-  var streamTypes = {
-    'single subscription': () => StreamController(),
-    'broadcast': () => StreamController.broadcast()
-  };
-  for (var streamType in streamTypes.keys) {
+  for (var streamType in streamTypes) {
     group('Stream type [$streamType]', () {
-      StreamController values;
-      List emittedValues;
+      StreamController<int> values;
+      List<int> emittedValues;
       bool valuesCanceled;
       bool isDone;
-      List errors;
-      Stream transformed;
-      StreamSubscription subscription;
+      Stream<int> transformed;
+      StreamSubscription<int> subscription;
 
-      void setUpStreams(StreamTransformer transformer) {
+      void setUpStreams(StreamTransformer<int, int> transformer) {
         valuesCanceled = false;
-        values = streamTypes[streamType]()
+        values = createController(streamType)
           ..onCancel = () {
             valuesCanceled = true;
           };
         emittedValues = [];
-        errors = [];
         isDone = false;
         transformed = values.stream.transform(transformer);
-        subscription = transformed
-            .listen(emittedValues.add, onError: errors.add, onDone: () {
+        subscription = transformed.listen(emittedValues.add, onDone: () {
           isDone = true;
         });
       }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -6,6 +6,20 @@ import 'dart:async';
 
 /// Cycle the event loop to ensure timers are started, then wait for a delay
 /// longer than [milliseconds] to allow for the timer to fire.
-Future waitForTimer(int milliseconds) =>
+Future<void> waitForTimer(int milliseconds) =>
     Future(() {/* ensure Timer is started*/})
         .then((_) => Future.delayed(Duration(milliseconds: milliseconds + 1)));
+
+StreamController<T> createController<T>(String streamType) {
+  switch (streamType) {
+    case 'single subscription':
+      return StreamController<T>();
+    case 'broadcast':
+      return StreamController<T>.broadcast();
+    default:
+      throw ArgumentError.value(
+          streamType, 'streamType', 'Must be one of $streamTypes');
+  }
+}
+
+const streamTypes = ['single subscription', 'broadcast'];


### PR DESCRIPTION
Most changes are in tests where we implicitly were using `<dynamic>` but
only ever passing a single type. Add specific types and clean up the few
cases where a different type from the norm was used. Extract utilities
for constructing both types of stream to do the tests in a loop, since
it's not using function literals anymore it can be a generic function.

In `lib/` add a few `<void>` type arguments for things like "trigger"
streams since we were never reading the value.