### PR TITLE
Fix travis to fail on analysis lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ dart_task:
   - test
   - test -p chrome
   - dartfmt
-  - dartanalyzer
+  - dartanalyzer: --fatal-warnings --fatal-infos .

--- a/lib/src/async_map.dart
+++ b/lib/src/async_map.dart
@@ -41,8 +41,7 @@ extension AsyncMap<T> on Stream<T> {
     var workFinished = StreamController<void>()
       // Let the first event through.
       ..add(null);
-    return this
-        .buffer(workFinished.stream)
+    return buffer(workFinished.stream)
         .transform(_asyncMapThen(convert, workFinished.add));
   }
 


### PR DESCRIPTION
Fix a case of `unnecessary_this` that was missed.