### PR TITLE
Remove author from pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,5 @@
 name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
-author: Dart Team <misc@dartlang.org>
 homepage: https://www.github.com/dart-lang/stream_transform
 version: 1.1.0
 


### PR DESCRIPTION
Upon publish I was notified that this is no longer useful and can be
removed.