### PR TITLE
Fix newly enforced package:pedantic lints

### DIFF
--- a/lib/src/aggregate_sample.dart
+++ b/lib/src/aggregate_sample.dart
@@ -32,13 +32,13 @@ class AggregateSample<S, T> extends StreamTransformerBase<S, T> {
     StreamSubscription<S> valueSub;
     StreamSubscription<void> triggerSub;
 
-    emit() {
+    void emit() {
       controller.add(currentResults);
       currentResults = null;
       waitingForTrigger = true;
     }
 
-    onValue(S value) {
+    void onValue(S value) {
       currentResults = _aggregate(value, currentResults);
 
       if (!waitingForTrigger) emit();
@@ -49,7 +49,7 @@ class AggregateSample<S, T> extends StreamTransformerBase<S, T> {
       }
     }
 
-    onValuesDone() {
+    void onValuesDone() {
       isValueDone = true;
       if (currentResults == null) {
         triggerSub?.cancel();
@@ -57,7 +57,7 @@ class AggregateSample<S, T> extends StreamTransformerBase<S, T> {
       }
     }
 
-    onTrigger(_) {
+    void onTrigger(_) {
       waitingForTrigger = false;
 
       if (currentResults != null) emit();
@@ -68,7 +68,7 @@ class AggregateSample<S, T> extends StreamTransformerBase<S, T> {
       }
     }
 
-    onTriggerDone() {
+    void onTriggerDone() {
       isTriggerDone = true;
       if (waitingForTrigger) {
         valueSub?.cancel();

--- a/lib/src/async_map.dart
+++ b/lib/src/async_map.dart
@@ -89,7 +89,7 @@ extension AsyncMap<T> on Stream<T> {
   ///
   /// The result stream will not close until the source stream closes and all
   /// pending conversions have finished.
-  Stream<S> concurrentAsyncMap<S>(FutureOr<S> convert(T event)) {
+  Stream<S> concurrentAsyncMap<S>(FutureOr<S> Function(T) convert) {
     var valuesWaiting = 0;
     var sourceDone = false;
     return transform(fromHandlers(handleData: (element, sink) {
@@ -116,7 +116,7 @@ T _dropPrevious<T>(T event, _) => event;
 /// rather than once per listener, and [then] is called after completing the
 /// work.
 StreamTransformer<S, T> _asyncMapThen<S, T>(
-    Future<T> convert(S event), void Function(void) then) {
+    Future<T> Function(S) convert, void Function(void) then) {
   Future<void> pendingEvent;
   return fromHandlers(handleData: (event, sink) {
     pendingEvent =

--- a/lib/src/concatenate.dart
+++ b/lib/src/concatenate.dart
@@ -75,17 +75,17 @@ class _FollowedBy<T> extends StreamTransformerBase<T, T> {
 
     Function currentDoneHandler;
 
-    listen() {
+    void listen() {
       subscription = currentStream.listen(controller.add,
           onError: controller.addError, onDone: () => currentDoneHandler());
     }
 
-    onSecondDone() {
+    void onSecondDone() {
       secondDone = true;
       controller.close();
     }
 
-    onFirstDone() {
+    void onFirstDone() {
       firstDone = true;
       currentStream = next;
       currentDoneHandler = onSecondDone;

--- a/lib/src/rate_limit.dart
+++ b/lib/src/rate_limit.dart
@@ -146,7 +146,7 @@ T _dropPrevious<T>(T element, _) => element;
 /// Creates a StreamTransformer which aggregates values until the source stream
 /// does not emit for [duration], then emits the aggregated values.
 StreamTransformer<T, R> _debounceAggregate<T, R>(
-    Duration duration, R collect(T element, R soFar)) {
+    Duration duration, R Function(T element, R soFar) collect) {
   Timer timer;
   R soFar;
   var shouldClose = false;

--- a/lib/src/scan.dart
+++ b/lib/src/scan.dart
@@ -14,7 +14,7 @@ extension Scan<T> on Stream<T> {
   /// called for elements in order, and the result stream always maintains the
   /// same order as the original.
   Stream<S> scan<S>(
-      S initialValue, FutureOr<S> combine(S previousValue, T element)) {
+      S initialValue, FutureOr<S> Function(S soFar, T element) combine) {
     var accumulated = initialValue;
     return asyncMap((value) {
       var result = combine(accumulated, value);

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -15,7 +15,7 @@ extension Switch<T> on Stream<T> {
   ///
   /// If the source stream is a broadcast stream, the result stream will be as
   /// well, regardless of the types of the streams produced by [convert].
-  Stream<S> switchMap<S>(Stream<S> convert(T event)) {
+  Stream<S> switchMap<S>(Stream<S> Function(T) convert) {
     return map(convert).switchLatest();
   }
 }

--- a/lib/src/where.dart
+++ b/lib/src/where.dart
@@ -34,7 +34,7 @@ extension Where<T> on Stream<T> {
   ///
   /// The result stream will not close until the source stream closes and all
   /// pending [test] calls have finished.
-  Stream<T> asyncWhere(FutureOr<bool> test(T element)) {
+  Stream<T> asyncWhere(FutureOr<bool> Function(T) test) {
     var valuesWaiting = 0;
     var sourceDone = false;
     return transform(fromHandlers(handleData: (element, sink) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 homepage: https://www.github.com/dart-lang/stream_transform
-version: 1.1.0
+version: 1.1.1-dev
 
 environment:
   sdk: ">=2.6.0 <3.0.0"

--- a/test/start_with_test.dart
+++ b/test/start_with_test.dart
@@ -18,7 +18,7 @@ void main() {
   List<int> emittedValues;
   bool isDone;
 
-  setupForStreamType(
+  void setupForStreamType(
       String streamType, Stream<int> Function(Stream<int>) transform) {
     emittedValues = [];
     isDone = false;


### PR DESCRIPTION
- always_declare_return_types
- use_function_type_syntax_for_parameters