### PR TITLE
Handle `null` returns from cancelled subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.1
+
+-   Fix a bug in `asyncMapSample`, `buffer`, `combineLatest`,
+    `combineLatestAll`, `merge`, and `mergeAll` which would cause an exception
+    when cancelling a subscription after using the transformer if the original
+    stream(s) returned `null` from cancelling their subscriptions.
+
 ## 1.1.0
 
 -   Add `concurrentAsyncExpand` to interleave events emitted by multiple sub

--- a/lib/src/aggregate_sample.dart
+++ b/lib/src/aggregate_sample.dart
@@ -107,8 +107,10 @@ class AggregateSample<S, T> extends StreamTransformerBase<S, T> {
         } else {
           triggerSub.pause();
         }
-        if (toCancel.isEmpty) return null;
-        return Future.wait(toCancel.map((s) => s.cancel()));
+        var cancels =
+            toCancel.map((s) => s.cancel()).where((f) => f != null).toList();
+        if (cancels.isEmpty) return null;
+        return Future.wait(cancels).then((_) => null);
       };
     };
     return controller.stream;

--- a/lib/src/combine_latest.dart
+++ b/lib/src/combine_latest.dart
@@ -175,11 +175,11 @@ class _CombineLatest<S, T, R> extends StreamTransformerBase<S, R> {
           };
       }
       controller.onCancel = () {
-        var cancelSource = sourceSubscription.cancel();
-        var cancelOther = otherSubscription.cancel();
+        var cancels = [sourceSubscription.cancel(), otherSubscription.cancel()]
+            .where((f) => f != null);
         sourceSubscription = null;
         otherSubscription = null;
-        return Future.wait([cancelSource, cancelOther]);
+        return Future.wait(cancels).then((_) => null);
       };
     };
     return controller.stream;
@@ -249,8 +249,12 @@ class _CombineLatestAll<T> extends StreamTransformerBase<T, List<T>> {
           };
       }
       controller.onCancel = () {
-        if (subscriptions.isEmpty) return null;
-        return Future.wait(subscriptions.map((s) => s.cancel()));
+        var cancels = subscriptions
+            .map((s) => s.cancel())
+            .where((f) => f != null)
+            .toList();
+        if (cancels.isEmpty) return null;
+        return Future.wait(cancels).then((_) => null);
       };
     };
     return controller.stream;

--- a/lib/src/merge.dart
+++ b/lib/src/merge.dart
@@ -124,8 +124,12 @@ class _Merge<T> extends StreamTransformerBase<T, T> {
           };
       }
       controller.onCancel = () {
-        if (subscriptions.isEmpty) return null;
-        return Future.wait(subscriptions.map((s) => s.cancel()));
+        var cancels = subscriptions
+            .map((s) => s.cancel())
+            .where((f) => f != null)
+            .toList();
+        if (cancels.isEmpty) return null;
+        return Future.wait(cancels).then((_) => null);
       };
     };
     return controller.stream;
@@ -172,7 +176,12 @@ class _MergeExpanded<T> extends StreamTransformerBase<Stream<T>, T> {
           };
       }
       controller.onCancel = () {
-        return Future.wait(subscriptions.map((s) => s.cancel()));
+        var cancels = subscriptions
+            .map((s) => s.cancel())
+            .where((f) => f != null)
+            .toList();
+        if (cancels.isEmpty) return null;
+        return Future.wait(cancels).then((_) => null);
       };
     };
     return controller.stream;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,12 @@
 name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 homepage: https://www.github.com/dart-lang/stream_transform
-version: 1.1.1-dev
+version: 1.1.1
 
 environment:
   sdk: ">=2.6.0 <3.0.0"
 
 dev_dependencies:
+  async: ^2.0.0
   pedantic: ^1.5.0
   test: ^1.0.0

--- a/test/async_map_sample_test.dart
+++ b/test/async_map_sample_test.dart
@@ -200,4 +200,13 @@ void main() {
       }
     });
   }
+  test('handles null response from cancel', () async {
+    var controller = StreamController<int>();
+
+    var subscription = NullOnCancelStream(controller.stream)
+        .asyncMapSample((_) async {})
+        .listen(null);
+
+    await subscription.cancel();
+  });
 }

--- a/test/buffer_test.dart
+++ b/test/buffer_test.dart
@@ -243,4 +243,13 @@ void main() {
       ]);
     });
   }
+
+  test('handles null response from cancel', () async {
+    var controller = StreamController<int>();
+    var trigger = StreamController<void>();
+    var subscription = NullOnCancelStream(controller.stream)
+        .buffer(trigger.stream)
+        .listen(null);
+    await subscription.cancel();
+  });
 }

--- a/test/combine_latest_all_test.dart
+++ b/test/combine_latest_all_test.dart
@@ -8,6 +8,8 @@ import 'package:test/test.dart';
 
 import 'package:stream_transform/stream_transform.dart';
 
+import 'utils.dart';
+
 Future<void> tick() => Future(() {});
 
 void main() {
@@ -163,5 +165,15 @@ void main() {
         await first.close();
       });
     });
+  });
+
+  test('handles null response from cancel', () async {
+    var source = StreamController<int>();
+    var other = StreamController<int>();
+
+    var subscription = NullOnCancelStream(source.stream)
+        .combineLatestAll([NullOnCancelStream(other.stream)]).listen(null);
+
+    await subscription.cancel();
   });
 }

--- a/test/combine_latest_test.dart
+++ b/test/combine_latest_test.dart
@@ -9,6 +9,8 @@ import 'package:test/test.dart';
 
 import 'package:stream_transform/stream_transform.dart';
 
+import 'utils.dart';
+
 void main() {
   group('combineLatest', () {
     test('flows through combine callback', () async {
@@ -167,6 +169,17 @@ void main() {
         expect(emittedValues, [3, 5]);
       });
     });
+  });
+
+  test('handles null response from cancel', () async {
+    var source = StreamController<int>();
+    var other = StreamController<int>();
+
+    var subscription = NullOnCancelStream(source.stream)
+        .combineLatest(NullOnCancelStream(other.stream), (a, b) => null)
+        .listen(null);
+
+    await subscription.cancel();
   });
 }
 

--- a/test/concurrent_async_expand_test.dart
+++ b/test/concurrent_async_expand_test.dart
@@ -184,4 +184,19 @@ void main() {
       });
     }
   }
+
+  test('hendles null response from cancel', () async {
+    var source = StreamController<int>();
+    var other = StreamController<int>();
+
+    var subscription = NullOnCancelStream(source.stream)
+        .concurrentAsyncExpand((_) => NullOnCancelStream(other.stream))
+        .listen(null);
+
+    source.add(1);
+
+    await Future<void>(() {});
+
+    await subscription.cancel();
+  });
 }

--- a/test/merge_test.dart
+++ b/test/merge_test.dart
@@ -8,6 +8,8 @@ import 'package:test/test.dart';
 
 import 'package:stream_transform/stream_transform.dart';
 
+import 'utils.dart';
+
 void main() {
   group('merge', () {
     test('includes all values', () async {
@@ -137,5 +139,16 @@ void main() {
       expect(firstListenerValues, [1, 2, 3]);
       expect(secondListenerValues, [1, 2, 3, 4, 5, 6]);
     });
+  });
+
+  test('handles null response rom cancel', () async {
+    var source = StreamController<int>();
+    var other = StreamController<int>();
+
+    var subscription = NullOnCancelStream(source.stream)
+        .merge(NullOnCancelStream(other.stream))
+        .listen(null);
+
+    await subscription.cancel();
   });
 }

--- a/test/switch_test.dart
+++ b/test/switch_test.dart
@@ -146,4 +146,17 @@ void main() {
       expect(transformed.isBroadcast, true);
     });
   });
+
+  test('handles null response from cancel', () async {
+    var outer = StreamController<Stream<int>>();
+    var inner = StreamController<int>();
+
+    var subscription =
+        NullOnCancelStream(outer.stream).switchLatest().listen(null);
+
+    outer.add(NullOnCancelStream(inner.stream));
+    await Future<void>(() {});
+
+    await subscription.cancel();
+  });
 }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:async/async.dart';
+
 /// Cycle the event loop to ensure timers are started, then wait for a delay
 /// longer than [milliseconds] to allow for the timer to fire.
 Future<void> waitForTimer(int milliseconds) =>
@@ -23,3 +25,26 @@ StreamController<T> createController<T>(String streamType) {
 }
 
 const streamTypes = ['single subscription', 'broadcast'];
+
+class NullOnCancelStream<T> extends StreamView<T> {
+  final Stream<T> _stream;
+
+  NullOnCancelStream(this._stream) : super(_stream);
+
+  @override
+  StreamSubscription<T> listen(void Function(T) onData,
+          {Function onError, void Function() onDone, bool cancelOnError}) =>
+      _NullOnCancelSubscription(_stream.listen(onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError));
+}
+
+class _NullOnCancelSubscription<T> extends DelegatingStreamSubscription<T> {
+  final StreamSubscription<T> _subscription;
+  _NullOnCancelSubscription(this._subscription) : super(_subscription);
+
+  @override
+  Future<void> cancel() {
+    _subscription.cancel();
+    return null;
+  }
+}


### PR DESCRIPTION
A call to `StreamSubscription.cancel` is allowed to return `null`,
though it never does using the `StreamController` from the SDK. If a
custom Stream implementation does synchronously cancel and return `null`
it could cause problems in a number of transformers which would attempt
to `Future.wait` on the results of the cancels.

- Update the places using `Future.wait` to filter out null results
  first.
- Refactor some places to use collection literals and conditional
  elements.
- Filter out nulls first, and if every canceled subscription was
  synchronous skip the call to `Future.wait` entirely.
- Add a custom Stream implementation which always returns `null` when
  it's subscription is canceled as a test utility.
- Add tests that would fail without the null filtering on each
  implementation that was updated.