### PR TITLE
Drop the _WhereType transformer definition

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 homepage: https://www.github.com/dart-lang/stream_transform
-version: 1.1.1
+version: 1.1.2-dev
 
 environment:
   sdk: ">=2.6.0 <3.0.0"


### PR DESCRIPTION
This was only required because of the challenges of being exposed as a
`StreamTransformer` and the subtyping rules for the generic arguments.
Now that we aren't exposing it as `StreamTransformer` we don't need
extra complications.