### PR TITLE
Fix the description of debounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.2-dev
+
 ## 1.1.1
 
 -   Fix a bug in `asyncMapSample`, `buffer`, `combineLatest`,

--- a/lib/src/rate_limit.dart
+++ b/lib/src/rate_limit.dart
@@ -9,8 +9,10 @@ import 'from_handlers.dart';
 
 /// Utilities to rate limit events.
 ///
-/// - [debounce] - emit the _first_ event at the _end_ of the period.
-/// - [debounceBuffer] - emit _all_ events at the _end_ of the period.
+/// - [debounce] - emit the _last_ event at the _end_ of a series of closely
+///   spaced events.
+/// - [debounceBuffer] - emit _all_ events at the _end_ of a series of closely
+///   spaced events.
 /// - [throttle] - emit the _first_ event at the _beginning_ of the period.
 /// - [audit] - emit the _last_ event at the _end_ of the period.
 /// - [buffer] - emit _all_ events on a _trigger_.


### PR DESCRIPTION
It is the most recent, or "last" event in a series that is emitted. See
discussion in dart-lang/tools#1769

Change the word "period" to "series of closely spaced events" since
there is no fixed length of time.