### PR TITLE
Strengthen Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,21 @@ branches:
   only: [master]
 dart:
   - dev
-  # 2.2.0
+  - 2.6.0
 cache:
   directories:
     - $HOME/.pub-cache
 dart_task:
-  - test
-  - test -p chrome
-  - dartfmt
-  - dartanalyzer: --fatal-warnings --fatal-infos .
+  - test --test-randomize-ordering-seed=random
+  - test -p chrome --test-randomize-ordering-seed=random
+
+matrix:
+  include:
+    - dart: dev
+      dart_task: dartfmt
+    - dart: dev
+      dart_task:
+        dartanalyzer: --fatal-warnings --fatal-infos .
+    - dart: 2.6.0
+      dart_task:
+        dartanalyzer: --fatal-warnings .


### PR DESCRIPTION
- Restore checks on the earliest supported SDK.
- Tests and analyzer with warnings and errors are run on both SDKs.
- Dartfmt, and analyzer with lints are run on only the dev SDK.
- Add test order randomization.