### PR TITLE
Add leading and trailing support to debounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 1.1.2-dev
+## 1.2.0-dev
+
+-  Add support for emitting the "leading" event in `debounce`.
 
 ## 1.1.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 homepage: https://www.github.com/dart-lang/stream_transform
-version: 1.1.2-dev
+version: 1.2.0-dev
 
 environment:
   sdk: ">=2.6.0 <3.0.0"


### PR DESCRIPTION
Closes dart-lang/tools#1769

Add support for immediately emitting the leading event of a series of
closely spaced events. By default continue to only emit the trailing
events.