### PR TITLE
Refactor to avoid `.cast<S>()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.1-dev
+
 ## 1.2.0
 
 -  Add support for emitting the "leading" event in `debounce`.

--- a/lib/src/where.dart
+++ b/lib/src/where.dart
@@ -17,7 +17,10 @@ extension Where<T> on Stream<T> {
   /// [S] should be a subtype of the stream's generic type, otherwise nothing of
   /// type [S] could possibly be emitted, however there is no static or runtime
   /// checking that this is the case.
-  Stream<S> whereType<S>() => where((e) => e is S).cast<S>();
+  Stream<S> whereType<S>() =>
+      transform(StreamTransformer.fromHandlers(handleData: (event, sink) {
+        if (event is S) sink.add(event);
+      }));
 
   /// Like [where] but allows the [test] to return a [Future].
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 homepage: https://www.github.com/dart-lang/stream_transform
-version: 1.2.0
+version: 1.2.1-dev
 
 environment:
   sdk: ">=2.6.0 <3.0.0"


### PR DESCRIPTION
Keeps us at a single type check with `event is S`.