### PR TITLE
Add trailing call to throttle

### DIFF
--- a/test/throttle_test.dart
+++ b/test/throttle_test.dart
@@ -73,6 +73,181 @@ void main() {
           });
         }
       });
+
+      group('throttle - trailingCall', () {
+        setUp(() async {
+          valuesCanceled = false;
+          values = createController(streamType)
+            ..onCancel = () {
+              valuesCanceled = true;
+            };
+          emittedValues = [];
+          isDone = false;
+          transformed = values.stream
+              .throttle(const Duration(milliseconds: 5), trailingCall: true);
+          subscription = transformed.listen(emittedValues.add, onDone: () {
+            isDone = true;
+          });
+        });
+
+        test('cancels values', () async {
+          await subscription.cancel();
+          expect(valuesCanceled, true);
+        });
+
+        test('swallows values that come faster than duration', () async {
+          values..add(1)..add(2);
+          await values.close();
+          await waitForTimer(5);
+          expect(emittedValues, [1]);
+        });
+
+        test('outputs multiple values spaced further than duration', () async {
+          values.add(1);
+          await waitForTimer(5);
+          values.add(2);
+          await waitForTimer(5);
+          expect(emittedValues, [1, 2]);
+        });
+
+        test('closes output immediately', () async {
+          values.add(1);
+          await waitForTimer(5);
+          values.add(2);
+          await values.close();
+          expect(isDone, true);
+        });
+
+        if (streamType == 'broadcast') {
+          test('multiple listeners all get values', () async {
+            var otherValues = [];
+            transformed.listen(otherValues.add);
+            values.add(1);
+            await Future(() {});
+            expect(emittedValues, [1]);
+            expect(otherValues, [1]);
+          });
+        }
+
+        test('trailingCall is fired with latest value', () async {
+          values..add(1)..add(2)..add(3);
+          await waitForTimer(5);
+
+          await values.close();
+          expect(emittedValues, [1, 3]);
+        });
+
+        test('add values during trailingCall', () async {
+          values..add(1)..add(2)..add(3);
+          await waitForTimer(5);
+
+          values..add(4)..add(5);
+          await waitForTimer(5);
+
+          await values.close();
+          expect(emittedValues, [1, 3, 5]);
+        });
+
+        test(
+            'add values during trailingCall and close stream before next trailingCall fires',
+            () async {
+          values..add(1)..add(2)..add(3);
+          await waitForTimer(5);
+
+          values..add(4)..add(5);
+          await values.close();
+          await waitForTimer(5);
+
+          expect(emittedValues, [1, 3]);
+        });
+      });
+
+      group('throttle - trailingCall with trailing', () {
+        setUp(() async {
+          valuesCanceled = false;
+          values = createController(streamType)
+            ..onCancel = () {
+              valuesCanceled = true;
+            };
+          emittedValues = [];
+          isDone = false;
+          transformed = values.stream.throttle(const Duration(milliseconds: 5),
+              trailingCall: true, trailing: true);
+          subscription = transformed.listen(emittedValues.add, onDone: () {
+            isDone = true;
+          });
+        });
+
+        test('cancels values', () async {
+          await subscription.cancel();
+          expect(valuesCanceled, true);
+        });
+
+        test('not swallows latest value that come faster than duration',
+            () async {
+          values..add(1)..add(2)..add(3);
+          await values.close();
+          await waitForTimer(5);
+          expect(emittedValues, [1, 3]);
+        });
+
+        test('outputs multiple values spaced further than duration', () async {
+          values.add(1);
+          await waitForTimer(5);
+          values.add(2);
+          await waitForTimer(5);
+          expect(emittedValues, [1, 2]);
+        });
+
+        test('closes output immediately', () async {
+          values..add(1)..add(2);
+          await values.close();
+          expect(isDone, false);
+        });
+
+        if (streamType == 'broadcast') {
+          test('multiple listeners all get values', () async {
+            var otherValues = [];
+            transformed.listen(otherValues.add);
+            values.add(1);
+            await Future(() {});
+            expect(emittedValues, [1]);
+            expect(otherValues, [1]);
+          });
+        }
+
+        test('trailingCall is fired with latest value', () async {
+          values..add(1)..add(2)..add(3);
+          await waitForTimer(5);
+
+          await values.close();
+          expect(emittedValues, [1, 3]);
+        });
+
+        test('add values during trailingCall', () async {
+          values..add(1)..add(2)..add(3);
+          await waitForTimer(5);
+
+          values..add(4)..add(5);
+          await waitForTimer(5);
+
+          await values.close();
+          expect(emittedValues, [1, 3, 5]);
+        });
+
+        test(
+            'add values during trailingCall and close stream during next trailingCall fires',
+            () async {
+          values..add(1)..add(2)..add(3);
+          await waitForTimer(5);
+
+          values..add(4)..add(5);
+          await values.close();
+          await waitForTimer(5);
+
+          expect(emittedValues, [1, 3, 5]);
+        });
+      });
     });
   }
 }


### PR DESCRIPTION
Hello, I made some changes on throttle Stream to support trailing calls like in [underscorejs](https://underscorejs.org/docs/underscore.html#section-85) / [lodash](https://lodash.com/docs/4.17.15#throttle).

I encountered this problem while made some improvements on [flutter map](https://github.com/johnpryan/flutter_map/pull/572)  when I needed to detect tiles which should be downloaded while user is panning (basicly I didn't wanted to call _update tiles method every time during panning (performance reasons) so throttle was a good choice however I needed to make sure _update is recalled if a new value was added to stream during throttling).

```
source.throttle(Duration(seconds: 2));
source: 1-23----4---5-67|
result: 1-2-----4---5-6-|
```

```
source.throttle(Duration(seconds: 2), trailingCall: true);
source: 1-23----4---5-67|
result: 1-2-3---4---5-6-|
```

```
source.throttle(Duration(seconds: 2), trailingCall: true, trailing: true);
source: 1-23----4---5-67|
result: 1-2-3---4---5-6-7|
```