### PR TITLE
Bump min SDK to workaround broken analyzer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
   only: [master]
 dart:
   - dev
-  - 2.6.0
+  - 2.7.0
 cache:
   directories:
     - $HOME/.pub-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ matrix:
     - dart: dev
       dart_task:
         dartanalyzer: --fatal-warnings --fatal-infos .
-    - dart: 2.6.0
+    - dart: 2.7.0
       dart_task:
         dartanalyzer: --fatal-warnings .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.2.1-dev
 
-* Improve tests of `switchMap` and improve documentation with links and clarification.
+- Improve tests of `switchMap` and improve documentation with links and
+  clarification.
 
 ## 1.2.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/dart-lang/stream_transform
 version: 1.2.1-dev
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dev_dependencies:
   async: ^2.0.0


### PR DESCRIPTION
There is a broken version of `package:analyzer` that causes issues on
travis for the `2.6.0` SDK. There is relatively little need to maintain
support for an SDK that old, so bump the minimum rather than pin
analyzer and be unable to pick up newer versions.

https://github.com/dart-lang/sdk/issues/42888

Fix formatting in changelog.