### PR TITLE
Remove unused async import.

### DIFF
--- a/lib/src/tap.dart
+++ b/lib/src/tap.dart
@@ -1,8 +1,6 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import 'dart:async';
-
 import 'from_handlers.dart';
 
 /// A utility to chain extra behavior on a stream.


### PR DESCRIPTION
Since this version does not support dart 2.0, the async import is
unnecessary.