### PR TITLE
Refactor to remove StreamTransformer instantiation

### DIFF
--- a/lib/src/concatenate.dart
+++ b/lib/src/concatenate.dart
@@ -17,11 +17,67 @@ extension Concatenate<T> on Stream<T> {
   /// to and never canceled since there may be broadcast listeners added later.
   ///
   /// If a broadcast stream follows any other stream it will miss any events or
-  /// errors which occur before the first stream is done. If a broadcast stream
-  /// follows a single-subscription stream, pausing the stream while it is
-  /// listening to the second stream will cause events to be dropped rather than
-  /// buffered.
-  Stream<T> followedBy(Stream<T> next) => transform(_FollowedBy(next));
+  /// errors which occur before the original stream is done. If a broadcast
+  /// stream follows a single-subscription stream, pausing the stream while it
+  /// is listening to the second stream will cause events to be dropped rather
+  /// than buffered.
+  Stream<T> followedBy(Stream<T> next) {
+    var controller = isBroadcast
+        ? StreamController<T>.broadcast(sync: true)
+        : StreamController<T>(sync: true);
+
+    next = isBroadcast && !next.isBroadcast ? next.asBroadcastStream() : next;
+
+    StreamSubscription<T>? subscription;
+    var currentStream = this;
+    var thisDone = false;
+    var secondDone = false;
+
+    late void Function() currentDoneHandler;
+
+    void listen() {
+      subscription = currentStream.listen(controller.add,
+          onError: controller.addError, onDone: () => currentDoneHandler());
+    }
+
+    void onSecondDone() {
+      secondDone = true;
+      controller.close();
+    }
+
+    void onThisDone() {
+      thisDone = true;
+      currentStream = next;
+      currentDoneHandler = onSecondDone;
+      listen();
+    }
+
+    currentDoneHandler = onThisDone;
+
+    controller.onListen = () {
+      assert(subscription == null);
+      listen();
+      if (!isBroadcast) {
+        controller
+          ..onPause = () {
+            if (!thisDone || !next.isBroadcast) return subscription!.pause();
+            subscription!.cancel();
+            subscription = null;
+          }
+          ..onResume = () {
+            if (!thisDone || !next.isBroadcast) return subscription!.resume();
+            listen();
+          };
+      }
+      controller.onCancel = () {
+        if (secondDone) return null;
+        var toCancel = subscription!;
+        subscription = null;
+        return toCancel.cancel();
+      };
+    };
+    return controller.stream;
+  }
 
   /// Returns a stream which emits [initial] before any values from the original
   /// stream.
@@ -50,72 +106,5 @@ extension Concatenate<T> on Stream<T> {
       initial = initial.asBroadcastStream();
     }
     return initial.followedBy(this);
-  }
-}
-
-class _FollowedBy<T> extends StreamTransformerBase<T, T> {
-  final Stream<T> _next;
-
-  _FollowedBy(this._next);
-
-  @override
-  Stream<T> bind(Stream<T> first) {
-    var controller = first.isBroadcast
-        ? StreamController<T>.broadcast(sync: true)
-        : StreamController<T>(sync: true);
-
-    var next = first.isBroadcast && !_next.isBroadcast
-        ? _next.asBroadcastStream()
-        : _next;
-
-    StreamSubscription<T>? subscription;
-    var currentStream = first;
-    var firstDone = false;
-    var secondDone = false;
-
-    late void Function() currentDoneHandler;
-
-    void listen() {
-      subscription = currentStream.listen(controller.add,
-          onError: controller.addError, onDone: () => currentDoneHandler());
-    }
-
-    void onSecondDone() {
-      secondDone = true;
-      controller.close();
-    }
-
-    void onFirstDone() {
-      firstDone = true;
-      currentStream = next;
-      currentDoneHandler = onSecondDone;
-      listen();
-    }
-
-    currentDoneHandler = onFirstDone;
-
-    controller.onListen = () {
-      assert(subscription == null);
-      listen();
-      if (!first.isBroadcast) {
-        controller
-          ..onPause = () {
-            if (!firstDone || !next.isBroadcast) return subscription!.pause();
-            subscription!.cancel();
-            subscription = null;
-          }
-          ..onResume = () {
-            if (!firstDone || !next.isBroadcast) return subscription!.resume();
-            listen();
-          };
-      }
-      controller.onCancel = () {
-        if (secondDone) return null;
-        var toCancel = subscription!;
-        subscription = null;
-        return toCancel.cancel();
-      };
-    };
-    return controller.stream;
   }
 }

--- a/lib/src/from_handlers.dart
+++ b/lib/src/from_handlers.dart
@@ -5,6 +5,11 @@
 import 'dart:async';
 
 extension TransformByHandlers<S> on Stream<S> {
+  /// Transform a stream by callbacks.
+  ///
+  /// This is similar to `transform(StreamTransformer.fromHandler(...))` except
+  /// that the handlers are called once per event rather than called for the
+  /// same event for each listener on a broadcast stream.
   Stream<T> transformByHandlers<T>(
       {void Function(S, EventSink<T>)? onData,
       void Function(Object, StackTrace, EventSink<T>)? onError,

--- a/lib/src/from_handlers.dart
+++ b/lib/src/from_handlers.dart
@@ -4,46 +4,16 @@
 
 import 'dart:async';
 
-/// Like [new StreamTransformer.fromHandlers] but the handlers are called once
-/// per event rather than once per listener for broadcast streams.
-StreamTransformer<S, T> fromHandlers<S, T>(
-        {void Function(S, EventSink<T>)? handleData,
-        void Function(Object, StackTrace, EventSink<T>)? handleError,
-        void Function(EventSink<T>)? handleDone}) =>
-    _StreamTransformer(
-        handleData: handleData,
-        handleError: handleError,
-        handleDone: handleDone);
+extension TransformByHandlers<S> on Stream<S> {
+  Stream<T> transformByHandlers<T>(
+      {void Function(S, EventSink<T>)? onData,
+      void Function(Object, StackTrace, EventSink<T>)? onError,
+      void Function(EventSink<T>)? onDone}) {
+    final handleData = onData ?? _defaultHandleData;
+    final handleError = onError ?? _defaultHandleError;
+    final handleDone = onDone ?? _defaultHandleDone;
 
-class _StreamTransformer<S, T> extends StreamTransformerBase<S, T> {
-  final void Function(S, EventSink<T>) _handleData;
-  final void Function(EventSink<T>) _handleDone;
-  final void Function(Object, StackTrace, EventSink<T>) _handleError;
-
-  _StreamTransformer(
-      {void Function(S, EventSink<T>)? handleData,
-      void Function(Object, StackTrace, EventSink<T>)? handleError,
-      void Function(EventSink<T>)? handleDone})
-      : _handleData = handleData ?? _defaultHandleData,
-        _handleError = handleError ?? _defaultHandleError,
-        _handleDone = handleDone ?? _defaultHandleDone;
-
-  static void _defaultHandleData<S, T>(S value, EventSink<T> sink) {
-    sink.add(value as T);
-  }
-
-  static void _defaultHandleError<T>(
-      Object error, StackTrace stackTrace, EventSink<T> sink) {
-    sink.addError(error, stackTrace);
-  }
-
-  static void _defaultHandleDone<T>(EventSink<T> sink) {
-    sink.close();
-  }
-
-  @override
-  Stream<T> bind(Stream<S> values) {
-    var controller = values.isBroadcast
+    var controller = isBroadcast
         ? StreamController<T>.broadcast(sync: true)
         : StreamController<T>(sync: true);
 
@@ -51,14 +21,14 @@ class _StreamTransformer<S, T> extends StreamTransformerBase<S, T> {
     controller.onListen = () {
       assert(subscription == null);
       var valuesDone = false;
-      subscription = values.listen((value) => _handleData(value, controller),
+      subscription = listen((value) => handleData(value, controller),
           onError: (Object error, StackTrace stackTrace) {
-        _handleError(error, stackTrace, controller);
+        handleError(error, stackTrace, controller);
       }, onDone: () {
         valuesDone = true;
-        _handleDone(controller);
+        handleDone(controller);
       });
-      if (!values.isBroadcast) {
+      if (!isBroadcast) {
         controller
           ..onPause = subscription!.pause
           ..onResume = subscription!.resume;
@@ -71,5 +41,18 @@ class _StreamTransformer<S, T> extends StreamTransformerBase<S, T> {
       };
     };
     return controller.stream;
+  }
+
+  static void _defaultHandleData<S, T>(S value, EventSink<T> sink) {
+    sink.add(value as T);
+  }
+
+  static void _defaultHandleError<T>(
+      Object error, StackTrace stackTrace, EventSink<T> sink) {
+    sink.addError(error, stackTrace);
+  }
+
+  static void _defaultHandleDone<T>(EventSink<T> sink) {
+    sink.close();
   }
 }

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -52,15 +52,8 @@ extension SwitchLatest<T> on Stream<Stream<T>> {
   ///
   /// If the source stream is a broadcast stream, the result stream will be as
   /// well, regardless of the types of streams emitted.
-  Stream<T> switchLatest() => transform(_SwitchTransformer<T>());
-}
-
-class _SwitchTransformer<T> extends StreamTransformerBase<Stream<T>, T> {
-  const _SwitchTransformer();
-
-  @override
-  Stream<T> bind(Stream<Stream<T>> outer) {
-    var controller = outer.isBroadcast
+  Stream<T> switchLatest() {
+    var controller = isBroadcast
         ? StreamController<T>.broadcast(sync: true)
         : StreamController<T>(sync: true);
 
@@ -68,7 +61,7 @@ class _SwitchTransformer<T> extends StreamTransformerBase<Stream<T>, T> {
       StreamSubscription<T>? innerSubscription;
       var outerStreamDone = false;
 
-      final outerSubscription = outer.listen(
+      final outerSubscription = listen(
           (innerStream) {
             innerSubscription?.cancel();
             innerSubscription = innerStream.listen(controller.add,
@@ -82,7 +75,7 @@ class _SwitchTransformer<T> extends StreamTransformerBase<Stream<T>, T> {
             outerStreamDone = true;
             if (innerSubscription == null) controller.close();
           });
-      if (!outer.isBroadcast) {
+      if (!isBroadcast) {
         controller
           ..onPause = () {
             innerSubscription?.pause();

--- a/lib/src/take_until.dart
+++ b/lib/src/take_until.dart
@@ -13,23 +13,14 @@ extension TakeUntil<T> on Stream<T> {
   /// which are emitted before the trigger, but have further asynchronous delays
   /// in transformations following the takeUtil, will still go through.
   /// Cancelling a subscription immediately stops values.
-  Stream<T> takeUntil(Future<void> trigger) => transform(_TakeUntil(trigger));
-}
-
-class _TakeUntil<T> extends StreamTransformerBase<T, T> {
-  final Future<void> _trigger;
-
-  _TakeUntil(this._trigger);
-
-  @override
-  Stream<T> bind(Stream<T> values) {
-    var controller = values.isBroadcast
+  Stream<T> takeUntil(Future<void> trigger) {
+    var controller = isBroadcast
         ? StreamController<T>.broadcast(sync: true)
         : StreamController<T>(sync: true);
 
     StreamSubscription<T>? subscription;
     var isDone = false;
-    _trigger.then((_) {
+    trigger.then((_) {
       if (isDone) return;
       isDone = true;
       subscription?.cancel();
@@ -38,13 +29,13 @@ class _TakeUntil<T> extends StreamTransformerBase<T, T> {
 
     controller.onListen = () {
       if (isDone) return;
-      subscription = values.listen(controller.add, onError: controller.addError,
-          onDone: () {
+      subscription =
+          listen(controller.add, onError: controller.addError, onDone: () {
         if (isDone) return;
         isDone = true;
         controller.close();
       });
-      if (!values.isBroadcast) {
+      if (!isBroadcast) {
         controller
           ..onPause = subscription!.pause
           ..onResume = subscription!.resume;

--- a/lib/src/tap.dart
+++ b/lib/src/tap.dart
@@ -25,20 +25,20 @@ extension Tap<T> on Stream<T> {
   Stream<T> tap(void Function(T)? onValue,
           {void Function(Object, StackTrace)? onError,
           void Function()? onDone}) =>
-      transform(fromHandlers(handleData: (value, sink) {
+      transformByHandlers(onData: (value, sink) {
         try {
           onValue?.call(value);
         } catch (_) {/*Ignore*/}
         sink.add(value);
-      }, handleError: (error, stackTrace, sink) {
+      }, onError: (error, stackTrace, sink) {
         try {
           onError?.call(error, stackTrace);
         } catch (_) {/*Ignore*/}
         sink.addError(error, stackTrace);
-      }, handleDone: (sink) {
+      }, onDone: (sink) {
         try {
           onDone?.call();
         } catch (_) {/*Ignore*/}
         sink.close();
-      }));
+      });
 }

--- a/lib/src/where.dart
+++ b/lib/src/where.dart
@@ -17,10 +17,9 @@ extension Where<T> on Stream<T> {
   /// [S] should be a subtype of the stream's generic type, otherwise nothing of
   /// type [S] could possibly be emitted, however there is no static or runtime
   /// checking that this is the case.
-  Stream<S> whereType<S>() =>
-      transform(StreamTransformer.fromHandlers(handleData: (event, sink) {
+  Stream<S> whereType<S>() => transformByHandlers(onData: (event, sink) {
         if (event is S) sink.add(event);
-      }));
+      });
 
   /// Like [where] but allows the [test] to return a [Future].
   ///
@@ -40,7 +39,7 @@ extension Where<T> on Stream<T> {
   Stream<T> asyncWhere(FutureOr<bool> Function(T) test) {
     var valuesWaiting = 0;
     var sourceDone = false;
-    return transform(fromHandlers(handleData: (element, sink) {
+    return transformByHandlers(onData: (element, sink) {
       valuesWaiting++;
       () async {
         try {
@@ -51,9 +50,9 @@ extension Where<T> on Stream<T> {
         valuesWaiting--;
         if (valuesWaiting <= 0 && sourceDone) sink.close();
       }();
-    }, handleDone: (sink) {
+    }, onDone: (sink) {
       sourceDone = true;
       if (valuesWaiting <= 0) sink.close();
-    }));
+    });
   }
 }


### PR DESCRIPTION
Directly implement the behavior from `bind` which is the `Stream` to
`Stream` implementation in the extension methods rather than in separate
`StreamTransformer` classes. This pattern has fewer potential issues
around generics since it's fully based on function calls which are
type checked appropriately unlike the `StreamTransformer` interface
which suffers from the incorrect covariant subtype relationships. It
also may avoid some unnecessary allocations as improve stack traces.

For the transforms that were changed, aim for better consistency around
generic type arguments. `T` is now more consistently the source stream
type, while `S` is the output stream type.