### PR TITLE
Allow null values in asyncMapSample and buffer

### DIFF
--- a/lib/src/rate_limit.dart
+++ b/lib/src/rate_limit.dart
@@ -166,27 +166,33 @@ extension RateLimit<T> on Stream<T> {
       {required bool leading, required bool trailing}) {
     Timer? timer;
     S? soFar;
+    var hasPending = false;
     var shouldClose = false;
     var emittedLatestAsLeading = false;
+
     return transformByHandlers(onData: (value, sink) {
+      void emit() {
+        sink.add(soFar as S);
+        soFar = null;
+        hasPending = false;
+      }
+
       timer?.cancel();
       soFar = collect(value, soFar);
+      hasPending = true;
       if (timer == null && leading) {
         emittedLatestAsLeading = true;
-        sink.add(soFar as S);
+        emit();
       } else {
         emittedLatestAsLeading = false;
       }
       timer = Timer(duration, () {
-        if (trailing && !emittedLatestAsLeading) sink.add(soFar as S);
-        if (shouldClose) {
-          sink.close();
-        }
-        soFar = null;
+        if (trailing && !emittedLatestAsLeading) emit();
+        if (shouldClose) sink.close();
         timer = null;
       });
     }, onDone: (EventSink<S> sink) {
-      if (soFar != null && trailing) {
+      if (hasPending && trailing) {
         shouldClose = true;
       } else {
         timer?.cancel();

--- a/test/async_map_sample_test.dart
+++ b/test/async_map_sample_test.dart
@@ -200,4 +200,9 @@ void main() {
       }
     });
   }
+
+  test('allows nulls', () async {
+    var stream = Stream<int?>.value(null);
+    await stream.asyncMapSample(expectAsync1((_) async {})).drain();
+  });
 }

--- a/test/debounce_test.dart
+++ b/test/debounce_test.dart
@@ -231,4 +231,9 @@ void main() {
       });
     });
   }
+  test('allows nulls', () async {
+    final values = Stream<int?>.fromIterable([null]);
+    final transformed = values.debounce(const Duration(milliseconds: 1));
+    expect(await transformed.toList(), [null]);
+  });
 }


### PR DESCRIPTION
Closes dart-lang/tools#1775

- Add a boolean to track whether we have a value since we can't use
  `null` as a sentinel value for a potentially nullable generic type.
- Replace `!` with `as S` to allow for nullable `S`.