### PR TITLE
Wait for cancel before next listen in switchLatest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1-dev
+
+- Wait for the future returned from `StreamSubscription.cancel()` before
+  listening to the subsequent stream in `switchLatest` and `switchMap`.
+
 ## 2.0.0
 
 - Migrate to null safety.

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -62,8 +62,8 @@ extension SwitchLatest<T> on Stream<Stream<T>> {
       var outerStreamDone = false;
 
       final outerSubscription = listen(
-          (innerStream) {
-            innerSubscription?.cancel();
+          (innerStream) async {
+            await innerSubscription?.cancel();
             innerSubscription = innerStream.listen(controller.add,
                 onError: controller.addError, onDone: () {
               innerSubscription = null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 repository: https://github.com/dart-lang/stream_transform
-version: 2.0.0
+version: 2.0.1-dev
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dev_dependencies:
   async: ^2.5.0

--- a/test/switch_test.dart
+++ b/test/switch_test.dart
@@ -113,25 +113,24 @@ void main() {
           expect(firstCanceled, true);
         });
 
-        test('waits for cancel before listening to subsequent stream',
-            () async {
-          var cancelWork = Completer<void>();
-          first.onCancel = () => cancelWork.future;
-          outer.add(first.stream);
-          await Future(() {});
+        if (innerType != 'broadcast') {
+          test('waits for cancel before listening to subsequent stream',
+              () async {
+            var cancelWork = Completer<void>();
+            first.onCancel = () => cancelWork.future;
+            outer.add(first.stream);
+            await Future(() {});
 
-          var cancelDone = false;
-          second.onListen = expectAsync0(() {
-            expect(cancelDone, true);
+            var cancelDone = false;
+            second.onListen = expectAsync0(() {
+              expect(cancelDone, true);
+            });
+            outer.add(second.stream);
+            await Future(() {});
+            cancelWork.complete();
+            cancelDone = true;
           });
-          outer.add(second.stream);
-          await Future(() {});
-          cancelWork.complete();
-          cancelDone = true;
-        },
-            skip: innerType == 'broadcast'
-                ? 'Broadcast streams do not forward cancelation future'
-                : false);
+        }
 
         test('cancels listener on current and outer stream on cancel',
             () async {

--- a/test/switch_test.dart
+++ b/test/switch_test.dart
@@ -113,6 +113,23 @@ void main() {
           expect(firstCanceled, true);
         });
 
+        test('waits for cancel before listening to subsequent stream',
+            () async {
+          var cancelWork = Completer<void>();
+          first.onCancel = () => cancelWork.future;
+          outer.add(first.stream);
+          await Future(() {});
+
+          var cancelDone = false;
+          second.onListen = expectAsync0(() {
+            expect(cancelDone, true);
+          });
+          outer.add(second.stream);
+          await Future(() {});
+          cancelWork.complete();
+          cancelDone = true;
+        });
+
         test('cancels listener on current and outer stream on cancel',
             () async {
           outer.add(first.stream);

--- a/test/switch_test.dart
+++ b/test/switch_test.dart
@@ -128,7 +128,10 @@ void main() {
           await Future(() {});
           cancelWork.complete();
           cancelDone = true;
-        });
+        },
+            skip: innerType == 'broadcast'
+                ? 'Broadcast streams do not forward cancelation future'
+                : false);
 
         test('cancels listener on current and outer stream on cancel',
             () async {


### PR DESCRIPTION
If a stream is performing resource cleanup on cancel it may be a problem
to listen to the next stream and start consuming resources before the
cleanup is done.