### PR TITLE
Wait for cancel before next listen in switchLatest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1-dev
+
+- Wait for the future returned from `StreamSubscription.cancel()` before
+  listening to the subsequent stream in `switchLatest` and `switchMap`.
+  
 ## 2.0.0
 
 - Migrate to null safety.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: stream_transform
 description: A collection of utilities to transform and manipulate streams.
 repository: https://github.com/dart-lang/stream_transform
-version: 2.0.0
+version: 2.0.1-dev
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dev_dependencies:
   async: ^2.5.0

--- a/test/switch_test.dart
+++ b/test/switch_test.dart
@@ -15,6 +15,7 @@ void main() {
       group('Outer type: [$outerType], Inner type: [$innerType]', () {
         late StreamController<int> first;
         late StreamController<int> second;
+        late StreamController<int> third;
         late StreamController<Stream<int>> outer;
 
         late List<int> emittedValues;
@@ -36,6 +37,7 @@ void main() {
               firstCanceled = true;
             };
           second = createController(innerType);
+          third = createController(innerType);
           emittedValues = [];
           errors = [];
           isDone = false;
@@ -49,16 +51,12 @@ void main() {
         test('forwards events', () async {
           outer.add(first.stream);
           await Future(() {});
-          first
-            ..add(1)
-            ..add(2);
+          first..add(1)..add(2);
           await Future(() {});
 
           outer.add(second.stream);
           await Future(() {});
-          second
-            ..add(3)
-            ..add(4);
+          second..add(3)..add(4);
           await Future(() {});
 
           expect(emittedValues, [1, 2, 3, 4]);
@@ -112,6 +110,66 @@ void main() {
           await Future(() {});
           expect(firstCanceled, true);
         });
+
+        if (innerType != 'broadcast') {
+          test('waits for cancel before listening to subsequent stream',
+              () async {
+            var cancelWork = Completer<void>();
+            first.onCancel = () => cancelWork.future;
+            outer.add(first.stream);
+            await Future(() {});
+
+            var cancelDone = false;
+            second.onListen = expectAsync0(() {
+              expect(cancelDone, true);
+            });
+            outer.add(second.stream);
+            await Future(() {});
+            cancelWork.complete();
+            cancelDone = true;
+          });
+
+          test('ignores all but the latest stream while waiting for cancel',
+              () async {
+            var cancelWork = Completer<void>();
+            first.onCancel = () => cancelWork.future;
+            outer.add(first.stream);
+            await Future(() {});
+
+            var cancelDone = false;
+            second.onListen = expectAsync0(() {}, count: 0);
+            third.onListen = expectAsync0(() {
+              expect(cancelDone, true);
+            });
+            outer..add(second.stream)..add(third.stream);
+            await Future(() {});
+            cancelWork.complete();
+            cancelDone = true;
+          });
+        }
+
+        if (outerType != 'broadcast' && innerType != 'broadcast') {
+          test('pausing while cancelling an inner stream is respected',
+              () async {
+            var cancelWork = Completer<void>();
+            first.onCancel = () => cancelWork.future;
+            outer.add(first.stream);
+            await Future(() {});
+
+            var cancelDone = false;
+            second.onListen = expectAsync0(() {
+              expect(cancelDone, true);
+            });
+            outer.add(second.stream);
+            await Future(() {});
+            subscription.pause();
+            cancelWork.complete();
+            cancelDone = true;
+            await Future(() {});
+            expect(second.isPaused, true);
+            subscription.resume();
+          });
+        }
 
         test('cancels listener on current and outer stream on cancel',
             () async {


### PR DESCRIPTION
If a stream is performing resource cleanup on cancel it may be a problem
to listen to the next stream and start consuming resources before the
cleanup is done.