### PR TITLE
Implement `sample`, add `longPoll` to `buffer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,56 @@ Blocks events for a duration after an event is successfully emitted.
 
 Like `Iterable.whereType` for a stream.
 
+### Comparison to Rx Operators
+
+The semantics and naming in this package have some overlap, and some conflict,
+with the [ReactiveX](https://reactivex.io/) suite of libraries. Some of the
+conflict is intentional - Dart `Stream` predates `Observable` and coherence with
+the Dart ecosystem semantics and naming is a strictly higher priority than
+consistency with ReactiveX.
+
+Rx Operator Category      | variation                                              | `stream_transform`
+------------------------- | ------------------------------------------------------ | ------------------
+[`sample`][rx_sample]     | `sample/throttleLast(Duration)`                        | No equivalent
+&#x200B;                  | `throttleFirst(Duration)`                              | [`throttle`][throttle]
+&#x200B;                  | `sample(Observable)`                                   | No equivalent
+[`debounce`][rx_debounce] | `debounce/throttleWithTimeout(Duration)`               | [`debounce`][debounce]
+&#x200B;                  | `debounce(Observable)`                                 | No equivalent
+[`buffer`][rx_buffer]     | `buffer(boundary)`, `bufferWithTime`,`bufferWithCount` | No equivalent
+&#x200B;                  | `buffer(boundaryClosingSelector)`                      | No equivalent[^1]
+RxJs extensions           | [`audit(callback)`][rxjs_audit]                        | No equivalent
+&#x200B;                  | [`auditTime(Duration)`][rxjs_auditTime]                | [`audit`][audit]
+&#x200B;                  | [`exhaustMap`][rxjs_exhaustMap]                        | No equivalent
+&#x200B;                  | [`throttleTime(trailing: true)`][rxjs_throttleTime]    | `throttle(trailing: true)`
+&#x200B;                  | `throttleTime(leading: false, trailing: true)`         | No equivalent
+No equivalent?            |                                                        | [`asyncMapBuffer`][asyncMapBuffer]
+&#x200B;                  |                                                        | [`asyncMapSample`][asyncMapSample]
+&#x200B;                  |                                                        | [`buffer`][buffer][^1]
+&#x200B;                  |                                                        | [`debounceBuffer`][debounceBuffer]
+&#x200B;                  |                                                        | `debounce(leading: true, trailing: false)`
+&#x200B;                  |                                                        | `debounce(leading: true, trailing: true)`
+
+[rx_sample]:https://reactivex.io/documentation/operators/sample.html
+[rx_debounce]:https://reactivex.io/documentation/operators/debounce.html
+[rx_buffer]:https://reactivex.io/documentation/operators/buffer.html
+[rxjs_audit]:https://rxjs.dev/api/operators/audit
+[rxjs_auditTime]:https://rxjs.dev/api/operators/auditTime
+[rxjs_throttleTime]:https://rxjs.dev/api/operators/throttleTime
+[rxjs_exhaustMap]:https://rxjs.dev/api/operators/exhaustMap
+[asyncMapBuffer]:https://pub.dev/documentation/stream_transform/latest/stream_transform/AsyncMap/asyncMapBuffer.html
+[asyncMapSample]:https://pub.dev/documentation/stream_transform/latest/stream_transform/AsyncMap/asyncMapSample.html
+[audit]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/audit.html
+[buffer]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/buffer.html
+[debounceBuffer]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/debounceBuffer.html
+[debounce]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/debounce.html
+[throttle]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/throttle.html
+[^1]: `stream_transform` `buffer` is closest to
+    [`buffer(bufferClosingSelector)`][rx_buffer], except where the trigger
+    emits while no events are buffered. ReactiveX will immediately emit and
+    empty list, while `stream_transform` will wait and emit a single element
+    list when the next event occurs. You can think of it like
+    `stream_transform` implemeting the "long polling" version of `buffer`.
+
 # Getting a `StreamTransformer` instance
 
 It may be useful to pass an instance of `StreamTransformer` so that it can be

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ consistency with ReactiveX.
 
 Rx Operator Category      | variation                                              | `stream_transform`
 ------------------------- | ------------------------------------------------------ | ------------------
-[`sample`][rx_sample]     | `sample/throttleLast(Duration)`                        | No equivalent
+[`sample`][rx_sample]     | `sample/throttleLast(Duration)`                        | No equivalent `sample(Stream.periodic(Duration))`
 &#x200B;                  | `throttleFirst(Duration)`                              | [`throttle`][throttle]
-&#x200B;                  | `sample(Observable)`                                   | No equivalent
+&#x200B;                  | `sample(Observable)`                                   | `sample(trigger, longPoll: false)`
 [`debounce`][rx_debounce] | `debounce/throttleWithTimeout(Duration)`               | [`debounce`][debounce]
 &#x200B;                  | `debounce(Observable)`                                 | No equivalent
 [`buffer`][rx_buffer]     | `buffer(boundary)`, `bufferWithTime`,`bufferWithCount` | No equivalent
-&#x200B;                  | `buffer(boundaryClosingSelector)`                      | No equivalent[^1]
+&#x200B;                  | `buffer(boundaryClosingSelector)`                      | `buffer(trigger, longPoll: false)`
 RxJs extensions           | [`audit(callback)`][rxjs_audit]                        | No equivalent
 &#x200B;                  | [`auditTime(Duration)`][rxjs_auditTime]                | [`audit`][audit]
 &#x200B;                  | [`exhaustMap`][rxjs_exhaustMap]                        | No equivalent
@@ -103,7 +103,8 @@ RxJs extensions           | [`audit(callback)`][rxjs_audit]                     
 &#x200B;                  | `throttleTime(leading: false, trailing: true)`         | No equivalent
 No equivalent?            |                                                        | [`asyncMapBuffer`][asyncMapBuffer]
 &#x200B;                  |                                                        | [`asyncMapSample`][asyncMapSample]
-&#x200B;                  |                                                        | [`buffer`][buffer][^1]
+&#x200B;                  |                                                        | [`buffer`][buffer]
+&#x200B;                  |                                                        | [`sample`][sample]
 &#x200B;                  |                                                        | [`debounceBuffer`][debounceBuffer]
 &#x200B;                  |                                                        | `debounce(leading: true, trailing: false)`
 &#x200B;                  |                                                        | `debounce(leading: true, trailing: true)`
@@ -119,6 +120,7 @@ No equivalent?            |                                                     
 [asyncMapSample]:https://pub.dev/documentation/stream_transform/latest/stream_transform/AsyncMap/asyncMapSample.html
 [audit]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/audit.html
 [buffer]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/buffer.html
+[sample]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/sample.html
 [debounceBuffer]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/debounceBuffer.html
 [debounce]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/debounce.html
 [throttle]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/throttle.html

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ consistency with ReactiveX.
 
 Rx Operator Category      | variation                                              | `stream_transform`
 ------------------------- | ------------------------------------------------------ | ------------------
-[`sample`][rx_sample]     | `sample/throttleLast(Duration)`                        | No equivalent `sample(Stream.periodic(Duration))`
+[`sample`][rx_sample]     | `sample/throttleLast(Duration)`                        | `sample(Stream.periodic(Duration), longPoll: false)`
 &#x200B;                  | `throttleFirst(Duration)`                              | [`throttle`][throttle]
 &#x200B;                  | `sample(Observable)`                                   | `sample(trigger, longPoll: false)`
 [`debounce`][rx_debounce] | `debounce/throttleWithTimeout(Duration)`               | [`debounce`][debounce]

--- a/README.md
+++ b/README.md
@@ -124,12 +124,6 @@ No equivalent?            |                                                     
 [debounceBuffer]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/debounceBuffer.html
 [debounce]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/debounce.html
 [throttle]:https://pub.dev/documentation/stream_transform/latest/stream_transform/RateLimit/throttle.html
-[^1]: `stream_transform` `buffer` is closest to
-    [`buffer(bufferClosingSelector)`][rx_buffer], except where the trigger
-    emits while no events are buffered. ReactiveX will immediately emit and
-    empty list, while `stream_transform` will wait and emit a single element
-    list when the next event occurs. You can think of it like
-    `stream_transform` implemeting the "long polling" version of `buffer`.
 
 # Getting a `StreamTransformer` instance
 

--- a/lib/src/async_map.dart
+++ b/lib/src/async_map.dart
@@ -67,7 +67,11 @@ extension AsyncMap<T> on Stream<T> {
     var workFinished = StreamController<void>()
       // Let the first event through.
       ..add(null);
-    return aggregateSample(workFinished.stream, _dropPrevious)
+    return aggregateSample(
+            trigger: workFinished.stream,
+            aggregate: _dropPrevious,
+            longPoll: true,
+            onEmpty: _ignore)
         ._asyncMapThen(convert, workFinished.add);
   }
 
@@ -128,3 +132,4 @@ extension AsyncMap<T> on Stream<T> {
 }
 
 T _dropPrevious<T>(T event, _) => event;
+void _ignore<T>(Sink<T> sink) {}

--- a/lib/src/rate_limit.dart
+++ b/lib/src/rate_limit.dart
@@ -221,14 +221,17 @@ extension RateLimit<T> on Stream<T> {
     });
   }
 
-  /// Returns a Stream  which collects values and emits when it sees a value on
-  /// [trigger].
+  /// Buffers the values emitted on this stream and emits them when [trigger]
+  /// emits an event.
   ///
-  /// If [longPoll] is `false`, then an event on [trigger] when there are no
-  /// buffered source events will immediately emit an empty list.
-  /// If [longPoll] is `true` (the default), then an event on [trigger] when
-  /// there are no buffereds source events will cause the next source event to
-  /// immediately flow to the result stream as a single element list.
+  /// If [longPoll] is `false`, if there are no buffered values when [trigger]
+  /// emits an empty list is immediately emitted.
+  ///
+  /// If [longPoll] is `true`, and there are no buffered values when [trigger]
+  /// emits one or more events, then the *next* value from this stream is
+  /// immediately emitted on the returned stream as a single element list.
+  /// Subsequent events on [trigger] while there have been no events on this
+  /// stream are ignored.
   ///
   /// The result stream will close as soon as there is a guarantee it will not
   /// emit any more events. There will not be any more events emitted if:
@@ -250,20 +253,29 @@ extension RateLimit<T> on Stream<T> {
           longPoll: longPoll,
           onEmpty: _empty);
 
-  /// Returns a Stream which emits the most recent new value from the source
+  /// Creates a stream which emits the most recent new value from the source
   /// stream when it sees a value on [trigger].
   ///
   /// If [longPoll] is `false`, then an event on [trigger] when there is no
-  /// pending recent source event will be ignored.
+  /// pending source event will be ignored.
   /// If [longPoll] is `true` (the default), then an event on [trigger] when
-  /// there is no pending recent source event will cause the next source event
+  /// there is no pending source event will cause the next source event
   /// to immediately flow to the result stream.
+  ///
+  /// If [longPoll] is `false`, if there is no pending source event when
+  /// [trigger] emits, then the trigger event will be ignored.
+  ///
+  /// If [longPoll] is `true`, and there are no buffered values when [trigger]
+  /// emits one or more events, then the *next* value from this stream is
+  /// immediately emitted on the returned stream as a single element list.
+  /// Subsequent events on [trigger] while there have been no events on this
+  /// stream are ignored.
   ///
   /// The result stream will close as soon as there is a guarantee it will not
   /// emit any more events. There will not be any more events emitted if:
   /// - [trigger] is closed and there is no waiting long poll.
-  /// - Or, the source stream is closed and any pending recent source event has
-  /// been delivered.
+  /// - Or, the source stream is closed and any pending source event has been
+  /// delivered.
   ///
   /// If the source stream is a broadcast stream, the result will be as well.
   /// Errors from the source stream or the trigger are immediately forwarded to

--- a/lib/src/rate_limit.dart
+++ b/lib/src/rate_limit.dart
@@ -224,15 +224,60 @@ extension RateLimit<T> on Stream<T> {
   /// Returns a Stream  which collects values and emits when it sees a value on
   /// [trigger].
   ///
-  /// If there are no pending values when [trigger] emits, the next value on the
-  /// source Stream will immediately flow through. Otherwise, the pending values
-  /// are released when [trigger] emits.
+  /// If [longPoll] is `false`, then an event on [trigger] when there are no
+  /// buffered source events will immediately emit an empty list.
+  /// If [longPoll] is `true` (the default), then an event on [trigger] when
+  /// there are no buffereds source events will cause the next source event to
+  /// immediately flow to the result stream as a single element list.
+  ///
+  /// The result stream will close as soon as there is a guarantee it will not
+  /// emit any more events. There will not be any more events emitted if:
+  /// - [trigger] is closed and there is no waiting long poll.
+  /// - Or, the source stream is closed and previously buffered events have been
+  /// delivered.
   ///
   /// If the source stream is a broadcast stream, the result will be as well.
   /// Errors from the source stream or the trigger are immediately forwarded to
   /// the output.
-  Stream<List<T>> buffer(Stream<void> trigger) =>
-      aggregateSample<List<T>>(trigger, _collect);
+  ///
+  /// See also:
+  /// - [sample] which use a [trigger] stream in the same way, but keeps only
+  /// the most recent source event.
+  Stream<List<T>> buffer(Stream<void> trigger, {bool longPoll = true}) =>
+      aggregateSample(
+          trigger: trigger,
+          aggregate: _collect,
+          longPoll: longPoll,
+          onEmpty: _empty);
+
+  /// Returns a Stream which emits the most recent new value from the source
+  /// stream when it sees a value on [trigger].
+  ///
+  /// If [longPoll] is `false`, then an event on [trigger] when there is no
+  /// pending recent source event will be ignored.
+  /// If [longPoll] is `true` (the default), then an event on [trigger] when
+  /// there is no pending recent source event will cause the next source event
+  /// to immediately flow to the result stream.
+  ///
+  /// The result stream will close as soon as there is a guarantee it will not
+  /// emit any more events. There will not be any more events emitted if:
+  /// - [trigger] is closed and there is no waiting long poll.
+  /// - Or, the source stream is closed and any pending recent source event has
+  /// been delivered.
+  ///
+  /// If the source stream is a broadcast stream, the result will be as well.
+  /// Errors from the source stream or the trigger are immediately forwarded to
+  /// the output.
+  ///
+  /// See also:
+  /// - [buffer] which use [trigger] stream in the same way, but keeps a list of
+  /// pending source events.
+  Stream<T> sample(Stream<void> trigger, {bool longPoll = true}) =>
+      aggregateSample(
+          trigger: trigger,
+          aggregate: _dropPrevious,
+          longPoll: longPoll,
+          onEmpty: _ignore);
 
   /// Aggregates values until the source stream does not emit for [duration],
   /// then emits the aggregated values.
@@ -279,3 +324,5 @@ extension RateLimit<T> on Stream<T> {
 
 T _dropPrevious<T>(T element, _) => element;
 List<T> _collect<T>(T event, List<T>? soFar) => (soFar ?? <T>[])..add(event);
+void _empty<T>(Sink<List<T>> sink) => sink.add([]);
+void _ignore<T>(Sink<T> sink) {}


### PR DESCRIPTION
Closes dart-lang/tools#1781

Add `longPoll` support to `aggregateSample`. This method is a package
private implementation detail.
- Refactor to named arguments for clarity at the calling sites.
- Add `longPoll` boolean argument and conditional behavior in each
  stream callback.
- Add `onEmpty` callback to let the caller decide whether to emit some
  default (empty list in the `buffer` case) or not emit at all (in the
  `sample` case) for triggers which do no set up a long poll and have
  no prior aggregated events.
- Switch `waitingForTrigger` to the inverted condition `activeLongPoll`
  since its a closer match to how the behavior is described in the docs.

Add `longPoll` argument to `buffer` and update the doc to describe the
conditional behavior. Add a section in the docs discussing the end of
stream behavior.

Add a `sample` method which is similar to `buffer`. Cross reference each
method in the docs.

Update the comparison table with Rx. Show that `buffer` is equivalent to
`buffer(longPoll: false)`, that `sample` is `sampel(longPoll: false)`. I
cannot find an equivalent Rx method to the `longPoll: true` behavior.