### PR TITLE
Rephrase "Returns a stream" docs

### DIFF
--- a/lib/src/async_expand.dart
+++ b/lib/src/async_expand.dart
@@ -18,7 +18,7 @@ extension AsyncExpand<T> on Stream<T> {
   /// before the [Stream] emitted by the previous element has closed.
   ///
   /// Events on the result stream will be emitted in the order they are emitted
-  /// by the sub streams, which may not match the order of the original stream.
+  /// by the sub streams, which may not match the order of this stream.
   ///
   /// Errors from [convert], the source stream, or any of the sub streams are
   /// forwarded to the result stream.
@@ -37,9 +37,8 @@ extension AsyncExpand<T> on Stream<T> {
   /// back.
   ///
   /// See also:
-  ///
-  ///  * [switchMap], which cancels subscriptions to the previous sub
-  ///    stream instead of concurrently emitting events from all sub streams.
+  /// - [switchMap], which cancels subscriptions to the previous sub stream
+  /// instead of concurrently emitting events from all sub streams.
   Stream<S> concurrentAsyncExpand<S>(Stream<S> Function(T) convert) {
     final controller = isBroadcast
         ? StreamController<S>.broadcast(sync: true)

--- a/lib/src/async_map.dart
+++ b/lib/src/async_map.dart
@@ -22,21 +22,22 @@ extension AsyncMap<T> on Stream<T> {
   /// Like [asyncMap] but events are buffered until previous events have been
   /// processed by [convert].
   ///
-  /// If the source stream is a broadcast stream the result will be as well. When
-  /// used with a broadcast stream behavior also differs from [Stream.asyncMap] in
-  /// that the [convert] function is only called once per event, rather than once
-  /// per listener per event.
+  /// If this stream is a broadcast stream the result will be as well.
+  /// When used with a broadcast stream behavior also differs from [asyncMap] in
+  /// that the [convert] function is only called once per event, rather than
+  /// once per listener per event.
   ///
-  /// The first event from the source stream is always passed to [convert] as a
-  /// List with a single element. After that events are buffered until the
-  /// previous Future returned from [convert] has fired.
+  /// The first event from this stream is always passed to [convert] as a
+  /// list with a single element.
+  /// After that, events are buffered until the previous Future returned from
+  /// [convert] has completed.
   ///
-  /// Errors from the source stream are forwarded directly to the result stream.
+  /// Errors from this stream are forwarded directly to the result stream.
   /// Errors during the conversion are also forwarded to the result stream and
   /// are considered completing work so the next values are let through.
   ///
-  /// The result stream will not close until the source stream closes and all
-  /// pending conversions have finished.
+  /// The result stream will not close until this stream closes and all pending
+  /// conversions have finished.
   Stream<S> asyncMapBuffer<S>(Future<S> Function(List<T>) convert) {
     var workFinished = StreamController<void>()
       // Let the first event through.
@@ -47,22 +48,22 @@ extension AsyncMap<T> on Stream<T> {
   /// Like [asyncMap] but events are discarded while work is happening in
   /// [convert].
   ///
-  /// If the source stream is a broadcast stream the result will be as well. When
-  /// used with a broadcast stream behavior also differs from [Stream.asyncMap] in
-  /// that the [convert] function is only called once per event, rather than once
-  /// per listener per event.
+  /// If this stream is a broadcast stream the result will be as well.
+  /// When used with a broadcast stream behavior also differs from [asyncMap] in
+  /// that the [convert] function is only called once per event, rather than
+  /// once per listener per event.
   ///
   /// If no work is happening when an event is emitted it will be immediately
   /// passed to [convert]. If there is ongoing work when an event is emitted it
   /// will be held until the work is finished. New events emitted will replace a
   /// pending event.
   ///
-  /// Errors from the source stream are forwarded directly to the result stream.
+  /// Errors from this stream are forwarded directly to the result stream.
   /// Errors during the conversion are also forwarded to the result stream and are
   /// considered completing work so the next values are let through.
   ///
-  /// The result stream will not close until the source stream closes and all
-  /// pending conversions have finished.
+  /// The result stream will not close until this stream closes and all pending
+  /// conversions have finished.
   Stream<S> asyncMapSample<S>(Future<S> Function(T) convert) {
     var workFinished = StreamController<void>()
       // Let the first event through.
@@ -79,19 +80,19 @@ extension AsyncMap<T> on Stream<T> {
   /// before processing for the previous element is finished.
   ///
   /// Events on the result stream will be emitted in the order that [convert]
-  /// completed which may not match the order of the original stream.
+  /// completed which may not match the order of this stream.
   ///
-  /// If the source stream is a broadcast stream the result will be as well.
+  /// If this stream is a broadcast stream the result will be as well.
   /// When used with a broadcast stream behavior also differs from [asyncMap] in
   /// that the [convert] function is only called once per event, rather than
   /// once per listener per event. The [convert] callback won't be called for
   /// events while a broadcast stream has no listener.
   ///
-  /// Errors from [convert] or the source stream are forwarded directly to the
+  /// Errors from [convert] or this stream are forwarded directly to the
   /// result stream.
   ///
-  /// The result stream will not close until the source stream closes and all
-  /// pending conversions have finished.
+  /// The result stream will not close until this stream closes and all pending
+  /// conversions have finished.
   Stream<S> concurrentAsyncMap<S>(FutureOr<S> Function(T) convert) {
     var valuesWaiting = 0;
     var sourceDone = false;

--- a/lib/src/combine_latest.dart
+++ b/lib/src/combine_latest.dart
@@ -7,8 +7,8 @@ import 'dart:async';
 /// Utilities to combine events from multiple streams through a callback or into
 /// a list.
 extension CombineLatest<T> on Stream<T> {
-  /// Returns a stream which combines the latest value from the source stream
-  /// with the latest value from [other] using [combine].
+  /// Combines the latest values from this stream with the latest values from
+  /// [other] using [combine].
   ///
   /// No event will be emitted until both the source stream and [other] have
   /// each emitted at least one event. If either the source stream or [other]

--- a/lib/src/concatenate.dart
+++ b/lib/src/concatenate.dart
@@ -6,21 +6,21 @@ import 'dart:async';
 
 /// Utilities to append or prepend to a stream.
 extension Concatenate<T> on Stream<T> {
-  /// Returns a stream which emits values and errors from [next] after the
-  /// original stream is complete.
+  /// Emits all values and errors from [next] following all values and errors
+  /// from this stream.
   ///
-  /// If the source stream never finishes, the [next] stream will never be
-  /// listened to.
+  /// If this stream never finishes, the [next] stream will never get a
+  /// listener.
   ///
-  /// If the source stream is a broadcast stream, the result will be as well.
+  /// If this stream is a broadcast stream, the result will be as well.
   /// If a single-subscription follows a broadcast stream it may be listened
   /// to and never canceled since there may be broadcast listeners added later.
   ///
   /// If a broadcast stream follows any other stream it will miss any events or
-  /// errors which occur before the original stream is done. If a broadcast
-  /// stream follows a single-subscription stream, pausing the stream while it
-  /// is listening to the second stream will cause events to be dropped rather
-  /// than buffered.
+  /// errors which occur before this stream is done.
+  /// If a broadcast stream follows a single-subscription stream, pausing the
+  /// stream while it is listening to the second stream will cause events to be
+  /// dropped rather than buffered.
   Stream<T> followedBy(Stream<T> next) {
     var controller = isBroadcast
         ? StreamController<T>.broadcast(sync: true)
@@ -79,28 +79,27 @@ extension Concatenate<T> on Stream<T> {
     return controller.stream;
   }
 
-  /// Returns a stream which emits [initial] before any values from the original
-  /// stream.
+  /// Emits [initial] before any values or errors from the this stream.
   ///
-  /// If the original stream is a broadcast stream the result will be as well.
+  /// If this stream is a broadcast stream the result will be as well.
   Stream<T> startWith(T initial) =>
       startWithStream(Future.value(initial).asStream());
 
-  /// Returns a stream which emits all values in [initial] before any values
-  /// from the original stream.
+  /// Emits all values in [initial] before any values or errors from this
+  /// stream.
   ///
-  /// If the original stream is a broadcast stream the result will be as well.
-  /// If the original stream is a broadcast stream it will miss any events which
+  /// If this stream is a broadcast stream the result will be as well.
+  /// If this stream is a broadcast stream it will miss any events which
   /// occur before the initial values are all emitted.
   Stream<T> startWithMany(Iterable<T> initial) =>
       startWithStream(Stream.fromIterable(initial));
 
-  /// Returns a stream which emits all values in [initial] before any values
-  /// from the original stream.
+  /// Emits all values and errors in [initial] before any values or errors from
+  /// this stream.
   ///
-  /// If the original stream is a broadcast stream the result will be as well. If
-  /// the original stream is a broadcast stream it will miss any events which
-  /// occur before [initial] closes.
+  /// If this stream is a broadcast stream the result will be as well.
+  /// If this stream is a broadcast stream it will miss any events which occur
+  /// before [initial] closes.
   Stream<T> startWithStream(Stream<T> initial) {
     if (isBroadcast && !initial.isBroadcast) {
       initial = initial.asBroadcastStream();

--- a/lib/src/merge.dart
+++ b/lib/src/merge.dart
@@ -6,11 +6,11 @@ import 'dart:async';
 
 /// Utilities to interleave events from multiple streams.
 extension Merge<T> on Stream<T> {
-  /// Returns a stream which emits values and errors from the source stream and
-  /// [other] in any order as they arrive.
+  /// Merges values and errors from this stream and [other] in any order as they
+  /// arrive.
   ///
-  /// The result stream will not close until both the source stream and [other]
-  /// have closed.
+  /// The result stream will not close until both this stream and [other] have
+  /// closed.
   ///
   /// For example:
   ///
@@ -20,7 +20,7 @@ extension Merge<T> on Stream<T> {
   ///     other:   ------4-------5--|
   ///     result:  1--2--4--3----5--|
   ///
-  /// If the source stream is a broadcast stream, the result stream will be as
+  /// If this stream is a broadcast stream, the result stream will be as
   /// well, regardless of [other]'s type. If a single subscription stream is
   /// merged into a broadcast stream it may never be canceled since there may be
   /// broadcast listeners added later.
@@ -30,10 +30,10 @@ extension Merge<T> on Stream<T> {
   /// be discarded.
   Stream<T> merge(Stream<T> other) => mergeAll([other]);
 
-  /// Returns a stream which emits values and errors from the source stream and
-  /// any stream in [others] in any order as they arrive.
+  /// Merges values and errors from this stream and any stream in [others] in
+  /// any order as they arrive.
   ///
-  /// The result stream will not close until the source stream and all streams
+  /// The result stream will not close until this stream and all streams
   /// in [others] have closed.
   ///
   /// For example:
@@ -45,7 +45,7 @@ extension Merge<T> on Stream<T> {
   ///     third:   ------6---------------7--|
   ///     result:  1--2--6--4--3----5----7--|
   ///
-  /// If the source stream is a broadcast stream, the result stream will be as
+  /// If this stream is a broadcast stream, the result stream will be as
   /// well, regardless the types of streams in [others]. If a single
   /// subscription stream is merged into a broadcast stream it may never be
   /// canceled since there may be broadcast listeners added later.

--- a/lib/src/scan.dart
+++ b/lib/src/scan.dart
@@ -6,13 +6,16 @@ import 'dart:async';
 
 /// A utility similar to [fold] which emits intermediate accumulations.
 extension Scan<T> on Stream<T> {
-  /// Like [fold], but instead of producing a single value it yields each
-  /// intermediate accumulation.
+  /// Emits a sequence of the accumulated values from repeatedly applying
+  /// [combine].
   ///
-  /// If [combine] returns a Future it will not be called again for subsequent
+  /// Like [fold], but instead of producing a single value it yields each
+  /// intermediate result.
+  ///
+  /// If [combine] returns a future it will not be called again for subsequent
   /// events from the source until it completes, therefore [combine] is always
   /// called for elements in order, and the result stream always maintains the
-  /// same order as the original.
+  /// same order as this stream.
   Stream<S> scan<S>(
       S initialValue, FutureOr<S> Function(S soFar, T element) combine) {
     var accumulated = initialValue;

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -35,8 +35,7 @@ extension Switch<T> on Stream<T> {
   /// and never canceled.
   ///
   /// See also:
-  ///
-  /// * [concurrentAsyncExpand], which emits events from all sub streams
+  /// - [concurrentAsyncExpand], which emits events from all sub streams
   ///   concurrently instead of cancelling subscriptions to previous subs streams.
   Stream<S> switchMap<S>(Stream<S> Function(T) convert) {
     return map(convert).switchLatest();

--- a/lib/src/take_until.dart
+++ b/lib/src/take_until.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 /// A utility to end a stream based on an external trigger.
 extension TakeUntil<T> on Stream<T> {
-  /// Returns a stream which emits values from the source stream until [trigger]
-  /// fires.
+  /// Takes values from this stream which are emitted before [trigger]
+  /// completes.
   ///
   /// Completing [trigger] differs from canceling a subscription in that values
   /// which are emitted before the trigger, but have further asynchronous delays

--- a/lib/src/tap.dart
+++ b/lib/src/tap.dart
@@ -8,15 +8,15 @@ extension Tap<T> on Stream<T> {
   /// Taps into this stream to allow additional handling on a single-subscriber
   /// stream without first wrapping as a broadcast stream.
   ///
-  /// The [onValue] callback will be called with every value from the source
-  /// stream before it is forwarded to listeners on the resulting stream. May be
-  /// null if only [onError] or [onDone] callbacks are needed.
+  /// The [onValue] callback will be called with every value from this stream
+  /// before it is forwarded to listeners on the resulting stream.
+  /// May be null if only [onError] or [onDone] callbacks are needed.
   ///
-  /// The [onError] callback will be called with every error from the source
-  /// stream before it is forwarded to listeners on the resulting stream.
+  /// The [onError] callback will be called with every error from this stream
+  /// before it is forwarded to listeners on the resulting stream.
   ///
-  /// The [onDone] callback will be called after the source stream closes and
-  /// before the resulting stream is closed.
+  /// The [onDone] callback will be called after this stream closes and before
+  /// the resulting stream is closed.
   ///
   /// Errors from any of the callbacks are caught and ignored.
   ///

--- a/lib/src/where.dart
+++ b/lib/src/where.dart
@@ -8,7 +8,7 @@ import 'from_handlers.dart';
 
 /// Utilities to filter events.
 extension Where<T> on Stream<T> {
-  /// Returns a stream which emits only the events which have type [S].
+  /// Discards events from this stream that are not of type [S].
   ///
   /// If the source stream is a broadcast stream the result will be as well.
   ///
@@ -21,15 +21,17 @@ extension Where<T> on Stream<T> {
         if (event is S) sink.add(event);
       });
 
+  /// Discards events from this stream based on an asynchronous [test] callback.
+  ///
   /// Like [where] but allows the [test] to return a [Future].
   ///
   /// Events on the result stream will be emitted in the order that [test]
-  /// completes which may not match the order of the original stream.
+  /// completes which may not match the order of this stream.
   ///
   /// If the source stream is a broadcast stream the result will be as well. When
-  /// used with a broadcast stream behavior also differs from [Stream.where] in
-  /// that the [test] function is only called once per event, rather than once
-  /// per listener per event.
+  /// used with a broadcast stream behavior also differs from [where] in that
+  /// the [test] function is only called once per event, rather than once per
+  /// listener per event.
   ///
   /// Errors from the source stream are forwarded directly to the result stream.
   /// Errors from [test] are also forwarded to the result stream.


### PR DESCRIPTION
Following up on a recent PR comment about this phrasing in the docs for
`buffer` and `sample`. Rewrite all doc headers that started with
"Returns a stream" to instead focus on the action on t the stream.

Reference `debounce` and `audit` from the `throttle` docs.

Move the paragraphs with comparisons to `throttle` and `debounce` to a
"See also" section in the `audit` docs.

Replace some "the original stream" and "the source stream" with "this
stream".

Where some comments had to reflow anyway, separate sentences onto their
own lines to reduce churn in the future in any sentence changes.

Remove some unnecessary `Stream.` prefixes in dartdoc references.