### PR TITLE
Extend timing buffer in audit test

### DIFF
--- a/test/audit_test.dart
+++ b/test/audit_test.dart
@@ -30,7 +30,7 @@ void main() {
           emittedValues = [];
           errors = [];
           isDone = false;
-          transformed = values.stream.audit(const Duration(milliseconds: 5));
+          transformed = values.stream.audit(const Duration(milliseconds: 6));
           subscription = transformed
               .listen(emittedValues.add, onError: errors.add, onDone: () {
             isDone = true;
@@ -80,11 +80,11 @@ void main() {
         test('does not starve output if many values come closer than duration',
             () async {
           values.add(1);
-          await Future.delayed(const Duration(milliseconds: 3));
+          await Future.delayed(const Duration(milliseconds: 4));
           values.add(2);
-          await Future.delayed(const Duration(milliseconds: 3));
+          await Future.delayed(const Duration(milliseconds: 4));
           values.add(3);
-          await waitForTimer(5);
+          await waitForTimer(6);
           expect(emittedValues, [2, 3]);
         });
 


### PR DESCRIPTION
This test relies on the particular interleaving of creating one `Timer`
and two `Future.delayed`. The 5 millisecond timer must fire after the
first 3 millisecond delay, and before the subsequent 3 millisecond
delay. On the web this timing became unreliable - the `Timer` may not
fire until after the full 6 milliseconds of both delays.

Extend the delays to 6 for the `Timer`, and 4 + 4 for the
`Future.delayed`. The extra millisecond of padding improves behavior on
the web.