### PR TITLE
Forward errors from trigger in takeUntil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 2.1.1-dev
 
 - Require Dart 2.18 or greater
+- Forward errors from the `trigger` future through to the result stream in
+  `takeUntil`. Previously an error would have not closed the stream, and instead
+  raised as an unhandled async error.
 
 ## 2.1.0
 

--- a/lib/src/take_until.dart
+++ b/lib/src/take_until.dart
@@ -13,6 +13,12 @@ extension TakeUntil<T> on Stream<T> {
   /// which are emitted before the trigger, but have further asynchronous delays
   /// in transformations following the takeUtil, will still go through.
   /// Cancelling a subscription immediately stops values.
+  ///
+  /// If [trigger] completes as an error, the error will be forwared through the
+  /// result stream before the result stream closes.
+  ///
+  /// If [trigger] completes as a value or as an error after this stream has
+  /// already ended, the completion will be ignored.
   Stream<T> takeUntil(Future<void> trigger) {
     var controller = isBroadcast
         ? StreamController<T>.broadcast(sync: true)
@@ -25,6 +31,12 @@ extension TakeUntil<T> on Stream<T> {
       isDone = true;
       subscription?.cancel();
       controller.close();
+    }, onError: (Object error, StackTrace stackTrace) {
+      if (isDone) return;
+      isDone = true;
+      controller
+        ..addError(error, stackTrace)
+        ..close();
     });
 
     controller.onListen = () {

--- a/lib/src/take_until.dart
+++ b/lib/src/take_until.dart
@@ -14,8 +14,8 @@ extension TakeUntil<T> on Stream<T> {
   /// in transformations following the takeUtil, will still go through.
   /// Cancelling a subscription immediately stops values.
   ///
-  /// If [trigger] completes as an error, the error will be forwared through the
-  /// result stream before the result stream closes.
+  /// If [trigger] completes as an error, the error will be forwarded through
+  /// the result stream before the result stream closes.
   ///
   /// If [trigger] completes as a value or as an error after this stream has
   /// already ended, the completion will be ignored.

--- a/test/take_until_test.dart
+++ b/test/take_until_test.dart
@@ -68,6 +68,20 @@ void main() {
         expect(isDone, true);
       });
 
+      test('forwards errors from the close trigger', () async {
+        closeTrigger.completeError('sad');
+        await Future(() {});
+        expect(errors, ['sad']);
+        expect(isDone, true);
+      });
+
+      test('ignores errors from the close trigger after stream closed', () async {
+        await values.close();
+        closeTrigger.completeError('sad');
+        await Future(() {});
+        expect(errors, []);
+      });
+
       test('cancels value subscription when trigger fires', () async {
         closeTrigger.complete();
         await Future(() {});

--- a/test/take_until_test.dart
+++ b/test/take_until_test.dart
@@ -75,7 +75,8 @@ void main() {
         expect(isDone, true);
       });
 
-      test('ignores errors from the close trigger after stream closed', () async {
+      test('ignores errors from the close trigger after stream closed',
+          () async {
         await values.close();
         closeTrigger.completeError('sad');
         await Future(() {});


### PR DESCRIPTION
It doesn't make sense to leave the error unhandled in all cases. When we
can handle the error through the stream, do so, otherwise ignore it.

This also makes `takeUntil` more useful for cases like timeouts.
