### PR TITLE
Use fake_async over waiting for timers with delays

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,5 +8,6 @@ environment:
 
 dev_dependencies:
   async: ^2.5.0
+  fake_async: ^1.3.0
   lints: ^2.0.0
   test: ^1.16.0

--- a/test/audit_test.dart
+++ b/test/audit_test.dart
@@ -47,47 +47,57 @@ void main() {
           expect(valuesCanceled, true);
         });
 
-        test('swallows values that come faster than duration', () async {
-          listen();
-          values
-            ..add(1)
-            ..add(2);
-          await values.close();
-          await waitForTimer(5);
-          expect(emittedValues, [2]);
+        test('swallows values that come faster than duration', () {
+          fakeAsync((async) {
+            listen();
+            values
+              ..add(1)
+              ..add(2)
+              ..close();
+            async.elapse(const Duration(milliseconds: 6));
+            expect(emittedValues, [2]);
+          });
         });
 
-        test('outputs multiple values spaced further than duration', () async {
-          listen();
-          values.add(1);
-          await waitForTimer(5);
-          values.add(2);
-          await waitForTimer(5);
-          expect(emittedValues, [1, 2]);
+        test('outputs multiple values spaced further than duration', () {
+          fakeAsync((async) {
+            listen();
+            values.add(1);
+            async.elapse(const Duration(milliseconds: 6));
+            values.add(2);
+            async.elapse(const Duration(milliseconds: 6));
+            expect(emittedValues, [1, 2]);
+          });
         });
 
-        test('waits for pending value to close', () async {
-          listen();
-          values.add(1);
-          await values.close();
-          expect(isDone, false);
-          await waitForTimer(5);
-          expect(isDone, true);
+        test('waits for pending value to close', () {
+          fakeAsync((async) {
+            listen();
+            values
+              ..add(1)
+              ..close();
+            expect(isDone, false);
+            async.elapse(const Duration(milliseconds: 6));
+            expect(isDone, true);
+          });
         });
 
-        test('closes output if there are no pending values', () async {
-          listen();
-          values.add(1);
-          await waitForTimer(5);
-          values.add(2);
-          await values.close();
-          expect(isDone, false);
-          await waitForTimer(5);
-          expect(isDone, true);
+        test('closes output if there are no pending values', () {
+          fakeAsync((async) {
+            listen();
+            values.add(1);
+            async.elapse(const Duration(milliseconds: 6));
+            values
+              ..add(2)
+              ..close();
+            expect(isDone, false);
+            async.elapse(const Duration(milliseconds: 6));
+            expect(isDone, true);
+          });
         });
 
         test('does not starve output if many values come closer than duration',
-            () async {
+            () {
           fakeAsync((async) {
             listen();
             values.add(1);
@@ -101,16 +111,18 @@ void main() {
         });
 
         if (streamType == 'broadcast') {
-          test('multiple listeners all get values', () async {
-            listen();
-            var otherValues = [];
-            transformed.listen(otherValues.add);
-            values
-              ..add(1)
-              ..add(2);
-            await waitForTimer(5);
-            expect(emittedValues, [2]);
-            expect(otherValues, [2]);
+          test('multiple listeners all get values', () {
+            fakeAsync((async) {
+              listen();
+              var otherValues = [];
+              transformed.listen(otherValues.add);
+              values
+                ..add(1)
+                ..add(2);
+              async.elapse(const Duration(milliseconds: 6));
+              expect(emittedValues, [2]);
+              expect(otherValues, [2]);
+            });
           });
         }
       });

--- a/test/audit_test.dart
+++ b/test/audit_test.dart
@@ -91,8 +91,10 @@ void main() {
               ..add(2)
               ..close();
             expect(isDone, false);
+            expect(emittedValues, [1]);
             async.elapse(const Duration(milliseconds: 6));
             expect(isDone, true);
+            expect(emittedValues, [1, 2]);
           });
         });
 
@@ -105,23 +107,30 @@ void main() {
             values.add(2);
             async.elapse(const Duration(milliseconds: 3));
             values.add(3);
-            async.elapse(const Duration(milliseconds: 7));
+            async.elapse(const Duration(milliseconds: 6));
             expect(emittedValues, [2, 3]);
           });
         });
 
         if (streamType == 'broadcast') {
-          test('multiple listeners all get values', () {
+          test('multiple listeners all get the values', () {
             fakeAsync((async) {
               listen();
+              values.add(1);
+              async.elapse(const Duration(milliseconds: 3));
+              values.add(2);
               var otherValues = [];
               transformed.listen(otherValues.add);
+              values.add(3);
+              async.elapse(const Duration(milliseconds: 3));
+              values.add(4);
+              async.elapse(const Duration(milliseconds: 3));
               values
-                ..add(1)
-                ..add(2);
+                ..add(5)
+                ..close();
               async.elapse(const Duration(milliseconds: 6));
-              expect(emittedValues, [2]);
-              expect(otherValues, [2]);
+              expect(emittedValues, [3, 5]);
+              expect(otherValues, [3, 5]);
             });
           });
         }

--- a/test/audit_test.dart
+++ b/test/audit_test.dart
@@ -86,7 +86,7 @@ void main() {
           values.add(3);
           await waitForTimer(6);
           expect(emittedValues, [2, 3]);
-        });
+        }, onPlatform: const {'browser': Skip('Timer timing is unreliable')});
 
         if (streamType == 'broadcast') {
           test('multiple listeners all get values', () async {

--- a/test/throttle_test.dart
+++ b/test/throttle_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:test/test.dart';
 
@@ -29,49 +30,68 @@ void main() {
           emittedValues = [];
           isDone = false;
           transformed = values.stream.throttle(const Duration(milliseconds: 5));
+        });
+
+        void listen() {
           subscription = transformed.listen(emittedValues.add, onDone: () {
             isDone = true;
           });
-        });
+        }
 
         test('cancels values', () async {
+          listen();
           await subscription.cancel();
           expect(valuesCanceled, true);
         });
 
-        test('swallows values that come faster than duration', () async {
-          values
-            ..add(1)
-            ..add(2);
-          await values.close();
-          await waitForTimer(5);
-          expect(emittedValues, [1]);
+        test('swallows values that come faster than duration', () {
+          fakeAsync((async) {
+            listen();
+            values
+              ..add(1)
+              ..add(2)
+              ..close();
+            async.elapse(const Duration(milliseconds: 6));
+            expect(emittedValues, [1]);
+          });
         });
 
-        test('outputs multiple values spaced further than duration', () async {
-          values.add(1);
-          await waitForTimer(5);
-          values.add(2);
-          await waitForTimer(5);
-          expect(emittedValues, [1, 2]);
+        test('outputs multiple values spaced further than duration', () {
+          fakeAsync((async) {
+            listen();
+            values.add(1);
+            async.elapse(const Duration(milliseconds: 6));
+            values.add(2);
+            async.elapse(const Duration(milliseconds: 6));
+            expect(emittedValues, [1, 2]);
+            async.elapse(const Duration(milliseconds: 6));
+          });
         });
 
-        test('closes output immediately', () async {
-          values.add(1);
-          await waitForTimer(5);
-          values.add(2);
-          await values.close();
-          expect(isDone, true);
+        test('closes output immediately', () {
+          fakeAsync((async) {
+            listen();
+            values.add(1);
+            async.elapse(const Duration(milliseconds: 6));
+            values
+              ..add(2)
+              ..close();
+            async.flushMicrotasks();
+            expect(isDone, true);
+          });
         });
 
         if (streamType == 'broadcast') {
-          test('multiple listeners all get values', () async {
-            var otherValues = <int>[];
-            transformed.listen(otherValues.add);
-            values.add(1);
-            await Future(() {});
-            expect(emittedValues, [1]);
-            expect(otherValues, [1]);
+          test('multiple listeners all get values', () {
+            fakeAsync((async) {
+              listen();
+              var otherValues = <int>[];
+              transformed.listen(otherValues.add);
+              values.add(1);
+              async.flushMicrotasks();
+              expect(emittedValues, [1]);
+              expect(otherValues, [1]);
+            });
           });
         }
       });
@@ -87,65 +107,84 @@ void main() {
           isDone = false;
           transformed = values.stream
               .throttle(const Duration(milliseconds: 5), trailing: true);
+        });
+        void listen() {
           subscription = transformed.listen(emittedValues.add, onDone: () {
             isDone = true;
           });
+        }
+
+        test('emits both first and last in a period', () {
+          fakeAsync((async) {
+            listen();
+            values
+              ..add(1)
+              ..add(2)
+              ..close();
+            async.elapse(const Duration(milliseconds: 6));
+            expect(emittedValues, [1, 2]);
+          });
         });
 
-        test('emits both first and last in a period', () async {
-          values
-            ..add(1)
-            ..add(2);
-          await values.close();
-          await waitForTimer(5);
-          expect(emittedValues, [1, 2]);
-        });
-
-        test('swallows values that are not the latest in a period', () async {
-          values
-            ..add(1)
-            ..add(2)
-            ..add(3);
-          await values.close();
-          await waitForTimer(5);
-          expect(emittedValues, [1, 3]);
+        test('swallows values that are not the latest in a period', () {
+          fakeAsync((async) {
+            listen();
+            values
+              ..add(1)
+              ..add(2)
+              ..add(3)
+              ..close();
+            async.elapse(const Duration(milliseconds: 6));
+            expect(emittedValues, [1, 3]);
+          });
         });
 
         test('waits to output the last value even if the stream closes',
             () async {
-          values
-            ..add(1)
-            ..add(2);
-          await values.close();
-          await Future(() {});
-          expect(isDone, false);
-          expect(emittedValues, [1],
-              reason: 'Should not be emitted until after duration');
-          await waitForTimer(5);
-          expect(emittedValues, [1, 2]);
-          expect(isDone, true);
+          fakeAsync((async) {
+            listen();
+            values
+              ..add(1)
+              ..add(2)
+              ..close();
+            async.flushMicrotasks();
+            expect(isDone, false);
+            expect(emittedValues, [1],
+                reason: 'Should not be emitted until after duration');
+            async.elapse(const Duration(milliseconds: 6));
+            expect(emittedValues, [1, 2]);
+            expect(isDone, true);
+            async.elapse(const Duration(milliseconds: 6));
+          });
         });
 
-        test('closes immediately if there is no pending value', () async {
-          values.add(1);
-          await values.close();
-          await Future(() {});
-          expect(isDone, true);
+        test('closes immediately if there is no pending value', () {
+          fakeAsync((async) {
+            listen();
+            values
+              ..add(1)
+              ..close();
+            async.flushMicrotasks();
+            expect(isDone, true);
+          });
         });
 
         if (streamType == 'broadcast') {
-          test('multiple listeners all get values', () async {
-            var otherValues = <int>[];
-            transformed.listen(otherValues.add);
-            values
-              ..add(1)
-              ..add(2);
-            await Future(() {});
-            expect(emittedValues, [1]);
-            expect(otherValues, [1]);
-            await waitForTimer(5);
-            expect(emittedValues, [1, 2]);
-            expect(otherValues, [1, 2]);
+          test('multiple listeners all get values', () {
+            fakeAsync((async) {
+              listen();
+              var otherValues = <int>[];
+              transformed.listen(otherValues.add);
+              values
+                ..add(1)
+                ..add(2);
+              async.flushMicrotasks();
+              expect(emittedValues, [1]);
+              expect(otherValues, [1]);
+              async.elapse(const Duration(milliseconds: 6));
+              expect(emittedValues, [1, 2]);
+              expect(otherValues, [1, 2]);
+            });
           });
         }
       });

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -4,12 +4,6 @@
 
 import 'dart:async';
 
-/// Cycle the event loop to ensure timers are started, then wait for a delay
-/// longer than [milliseconds] to allow for the timer to fire.
-Future<void> waitForTimer(int milliseconds) =>
-    Future(() {/* ensure Timer is started*/})
-        .then((_) => Future.delayed(Duration(milliseconds: milliseconds + 1)));
-
 StreamController<T> createController<T>(String streamType) {
   switch (streamType) {
     case 'single subscription':


### PR DESCRIPTION
On the web the timers may have some variance.

Replace all usages of `waitForTimer` utility to use `fakeAsync`.
Separate out the call to `Stream.listen` from `setUp` so it
happens in the fake async zone.