### PR TITLE
Remove default onData for transformByHandlers

### DIFF
--- a/lib/src/from_handlers.dart
+++ b/lib/src/from_handlers.dart
@@ -11,10 +11,9 @@ extension TransformByHandlers<S> on Stream<S> {
   /// that the handlers are called once per event rather than called for the
   /// same event for each listener on a broadcast stream.
   Stream<T> transformByHandlers<T>(
-      {void Function(S, EventSink<T>)? onData,
+      {required void Function(S, EventSink<T>) onData,
       void Function(Object, StackTrace, EventSink<T>)? onError,
       void Function(EventSink<T>)? onDone}) {
-    final handleData = onData ?? _defaultHandleData;
     final handleError = onError ?? _defaultHandleError;
     final handleDone = onDone ?? _defaultHandleDone;
 
@@ -26,7 +25,7 @@ extension TransformByHandlers<S> on Stream<S> {
     controller.onListen = () {
       assert(subscription == null);
       var valuesDone = false;
-      subscription = listen((value) => handleData(value, controller),
+      subscription = listen((value) => onData(value, controller),
           onError: (Object error, StackTrace stackTrace) {
         handleError(error, stackTrace, controller);
       }, onDone: () {
@@ -46,10 +45,6 @@ extension TransformByHandlers<S> on Stream<S> {
       };
     };
     return controller.stream;
-  }
-
-  static void _defaultHandleData<S, T>(S value, EventSink<T> sink) {
-    sink.add(value as T);
   }
 
   static void _defaultHandleError<T>(

--- a/test/from_handlers_test.dart
+++ b/test/from_handlers_test.dart
@@ -36,7 +36,8 @@ void main() {
   group('default from_handlers', () {
     group('Single subscription stream', () {
       setUp(() {
-        setUpForController(StreamController(), (s) => s.transformByHandlers());
+        setUpForController(StreamController(),
+            (s) => s.transformByHandlers(onData: (e, sink) => sink.add(e)));
       });
 
       test('has correct stream type', () {
@@ -75,8 +76,8 @@ void main() {
       late StreamSubscription<int> subscription2;
 
       setUp(() {
-        setUpForController(
-            StreamController.broadcast(), (s) => s.transformByHandlers());
+        setUpForController(StreamController.broadcast(),
+            (s) => s.transformByHandlers(onData: (e, sink) => sink.add(e)));
         emittedValues2 = [];
         errors2 = [];
         isDone2 = false;


### PR DESCRIPTION
Towards dart-lang/tools#1771

The default callback is not used in practice outside of tests, but it
included a cast to satisfy the type signature which looks worrying for
this type of library.

Make the callback required and add explicit callbacks (without a cast
since the types are consistent) in the tests which used it.
