### PR TITLE
Drop checks for unsound null values

### DIFF
--- a/lib/src/aggregate_sample.dart
+++ b/lib/src/aggregate_sample.dart
@@ -135,8 +135,6 @@ extension AggregateSample<T> on Stream<T> {
         } else {
           triggerSub!.pause();
         }
-        // Handle opt-out nulls
-        cancels.removeWhere((Object? f) => f == null);
         if (cancels.isEmpty) return null;
         return Future.wait(cancels).then((_) => null);
       };

--- a/lib/src/async_expand.dart
+++ b/lib/src/async_expand.dart
@@ -78,10 +78,7 @@ extension AsyncExpand<T> on Stream<T> {
       }
       controller.onCancel = () {
         if (subscriptions.isEmpty) return null;
-        var cancels = [for (var s in subscriptions) s.cancel()]
-          // Handle opt-out nulls
-          ..removeWhere((Object? f) => f == null);
-        return Future.wait(cancels).then((_) => null);
+        return [for (var s in subscriptions) s.cancel()].wait.then((_) => null);
       };
     };
     return controller.stream;

--- a/lib/src/combine_latest.dart
+++ b/lib/src/combine_latest.dart
@@ -128,9 +128,7 @@ extension CombineLatest<T> on Stream<T> {
         var cancels = [
           sourceSubscription!.cancel(),
           otherSubscription!.cancel()
-        ]
-          // Handle opt-out nulls
-          ..removeWhere((Object? f) => f == null);
+        ];
         sourceSubscription = null;
         otherSubscription = null;
         return Future.wait(cancels).then((_) => null);
@@ -230,11 +228,7 @@ extension CombineLatest<T> on Stream<T> {
       }
       controller.onCancel = () {
         if (subscriptions.isEmpty) return null;
-        var cancels = [for (var s in subscriptions) s.cancel()]
-          // Handle opt-out nulls
-          ..removeWhere((Object? f) => f == null);
-        if (cancels.isEmpty) return null;
-        return Future.wait(cancels).then((_) => null);
+        return [for (var s in subscriptions) s.cancel()].wait.then((_) => null);
       };
     };
     return controller.stream;

--- a/lib/src/merge.dart
+++ b/lib/src/merge.dart
@@ -90,11 +90,7 @@ extension Merge<T> on Stream<T> {
       }
       controller.onCancel = () {
         if (subscriptions.isEmpty) return null;
-        var cancels = [for (var s in subscriptions) s.cancel()]
-          // Handle opt-out nulls
-          ..removeWhere((Object? f) => f == null);
-        if (cancels.isEmpty) return null;
-        return Future.wait(cancels).then((_) => null);
+        return [for (var s in subscriptions) s.cancel()].wait.then((_) => null);
       };
     };
     return controller.stream;

--- a/lib/src/switch.dart
+++ b/lib/src/switch.dart
@@ -124,9 +124,7 @@ extension SwitchLatest<T> on Stream<Stream<T>> {
         var cancels = [
           if (!outerStreamDone) outerSubscription.cancel(),
           if (sub != null) sub.cancel(),
-        ]
-          // Handle opt-out nulls
-          ..removeWhere((Object? f) => f == null);
+        ];
         if (cancels.isEmpty) return null;
         return Future.wait(cancels).then(_ignore);
       };


### PR DESCRIPTION
Towards dart-lang/tools#1771

During the null safety migration it was possible for
`StreamSubscription.cancel()` to return `null` in some cases. Now that
this package is only used with sound null safe code it isn't possible
for these nulls to flow through anymore so it is not necessary to filter
for them.
