### PR TITLE
fix "throttle" docs typo

### DIFF
--- a/lib/src/rate_limit.dart
+++ b/lib/src/rate_limit.dart
@@ -105,7 +105,7 @@ extension RateLimit<T> on Stream<T> {
   ///
   /// For example:
   ///
-  ///     source.throtte(Duration(seconds: 6));
+  ///     source.throttle(Duration(seconds: 6));
   ///
   ///     source: 1-2-3---4-5-6---7-8-|
   ///     result: 1-------4-------7---|


### PR DESCRIPTION
Fixes a typo with the `throttle` docs ("throtte" -> "throttle")

I don't believe this is significant enough to merit a changelog entry, but happy to add one if the maintainers feel differently.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
